### PR TITLE
Fix dcm2niix versioning and upgrade fsleyes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,15 @@ cd testing/vagrant_{OS}
 vagrant up
 ```
 
-Next, ssh into the shell and run the `fsleyes-plugin-shimming-toolbox` installer:
+Next, ssh into the shell:
+
 ```
-cd src/fsleyes-plugin/shimming-toolbox/
+vagrant ssh
+```
+
+and run the `fsleyes-plugin-shimming-toolbox` installer:
+```
+cd src/fsleyes-plugin-shimming-toolbox/
 sudo make install
 source /Users/vagrant/.bashrc
 ```

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -8,6 +8,49 @@ ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
 
+function print() {
+  type=$1; shift
+  case "$type" in
+  # Display useful info (green)
+  info)
+    echo -e "\n\033[0;32m${*}\033[0m\n"
+    ;;
+  # To interact with user (no carriage return) (light green)
+  question)
+    echo -e -n "\n\033[0;92m${*}\033[0m"
+    ;;
+  # To display code that is being run in the Terminal (blue)
+  code)
+    echo -e "\n\033[0;34m${*}\033[0m\n"
+    ;;
+  # Warning message (yellow)
+  warning)
+    echo -e "\n\033[0;93m${*}\033[0m\n"
+    ;;
+  # Error message (red)
+  error)
+    echo -e "\n\033[0;31m${*}\033[0m\n"
+    ;;
+  esac
+}
+
+# Elegant exit with colored message
+function die() {
+  print error "$1"
+  exit 1
+}
+
+# Run a command and display it in color. Exit if error.
+# @input: string: command to run
+function run() {
+  ( # this subshell means the 'die' only kills this function and not the whole script;
+    # the caller can decide what to do instead (but with set -e that usually means terminating the whole script)
+    print code "$@"
+    if ! "$@" ; then
+      die "ERROR: Command failed."
+    fi
+  )
+}
 
 # Gets the shell rc file path based on the default shell.
 # @output: THE_RC and RC_FILE_PATH vars are modified
@@ -60,17 +103,19 @@ conda activate $VENV
 # set -u
 
 # Install fsleyes
+print info "Installing fsleyes"
 yes | conda install -c conda-forge fsleyes=0.34.2
 
 # Downgrade wxpython version due to bugs
+print info "Downgrading wxpython to 4.0.7"
 yes | conda install -c conda-forge wxpython=4.0.7
 
 # Install fsleyes-plugin-shimming-toolbox
-echo "Installing fsleyes-plugin-shimming-toolbox"
-python -m pip install .
+print info "Installing fsleyes-plugin-shimming-toolbox"
+run python -m pip install .
 
 # Create launchers
-echo "Creating launcher for fsleyes-plugin-shimming-toolbox..."
+print info "Creating launcher for fsleyes-plugin-shimming-toolbox"
 mkdir -p $ST_DIR/$BIN_DIR
 # echo $ST_DIR/python/envs/$VENV/bin/*st_*
 chmod +x shimming-toolbox.sh
@@ -81,4 +126,4 @@ export PATH=$ST_DIR/$BIN_DIR:$PATH
 
 edit_shellrc
 
-echo "Open a new Terminal window to load environment variables, or run: source $RC_FILE_PATH"
+print info "Open a new Terminal window to load environment variables, or run: source $RC_FILE_PATH"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -104,7 +104,7 @@ conda activate $VENV
 
 # Install fsleyes
 print info "Installing fsleyes"
-yes | conda install -c conda-forge fsleyes=0.34.2
+yes | conda install -c conda-forge fsleyes=1.0.15
 
 # Downgrade wxpython version due to bugs
 print info "Downgrading wxpython to 4.0.7"

--- a/testing/vagrant_linux/Vagrantfile
+++ b/testing/vagrant_linux/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/focal64"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
## Description

The `dcm2niix` package version will not update in the `fsleyes-plugin-shimming-toolbox` environment, as `fsleyes` is pinned to the older version (2019). We need to use the recent version from 2021. Paul McCarthy, the maintainer of `fsleyes`, has fixed this dependency issue in the more recent version of `fsleyes`, so we are going to try upgrading `fsleyes` to `1.0.15` in this PR. (Previously there were some bugs in the early versions of `fsleyes==1.0`, but it looks like they have been fixed now).

When testing locally, `dcm2niix=1.0.20210317` was installed along with `fsleyes`.

I have done some preliminary functionality testing for this upgrade, but it would be great to get everyone's input! 😄 

Addresses: https://github.com/shimming-toolbox/fsleyes-plugin-shimming-toolbox/issues/14