### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "Title summarizing bug"
+labels: bug
+assignees: ''
+
+---
+
+### Checklist
+
+- [ ] I've given this issue a self-descriptive, meaningful title (e.g. *Installation failure: problem creating launchers*)
+- [ ] I've described my environment
+- [ ] I've described the bug
+- [ ] I've described the steps to reproduce the behaviour
+- [ ] I've included screenshots
+- [ ] I've given this issue the correct labels
+
+### Environment details
+
+- [ ] I followed the [installation instructions](https://shimming-toolbox.org/en/latest/2_getting_started/1_installation.html)
+
+Project version:
+
+Operating System and version:
+
+Python version: 3.x.x
+
+Path to Python binary: /path/to/bin/python <!-- e.g. run `which python` from your project environment and paste the output here (/Users/johanan/.pyenv/versions/miniconda3-4.7.12/envs/shim_venv/bin/python) -->
+
+### Bug Description
+<!-- Describe the unexpected behaviour.
+
+If you experience an error, copy/paste the Terminal output (include your syntax) and please follow these guidelines for clarity:
+
+If there are fewer than 10 lines of text, embed them directly in your comment in Github. Enclose it in triple-ticks (```) to format as code.
+If there is 10+ lines, either use an external website such as pastebin (copy/paste your text and include the URL in your comment), or use collapsable Github markdown capabilities (https://gist.github.com/ericclemmons/b146fe5da72ca1f706b2ef72a20ac39d#using-details-in-github). -->
+
+### Reproduction Steps
+<!-- Steps to reproduce the behavior. Try to reproduce your issue using publicly-available data. If the error is data-specific, upload a zipped version of the data directly into github (not the full dataset, only what's required to be able to reproduce the error). If you cannot provide the file publicly, mention @jcohenadad in the issue description to coordinate. -->
+
+### Potential Reasons behind Bug:
+<!-- Any idea why this happened? (It's ok if you don't know) -->
+
+### Screenshots:
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+### Additional Context:
+<!-- Add any other context about the problem here (such as **documentation**). -->

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,24 @@
+---
+name: Enhancement Request
+about: Let's make an existing feature better
+title: "Title summarizing enhancement of an existing feature"
+labels: feature
+assignees: ''
+
+---
+
+### Checklist
+
+- [ ] I've given this issue a self-descriptive, meaningful title (e.g. *Document the use of config/dcm2bids.json*)
+- [ ] I've described the enhancement for an existing feature
+- [ ] (optional) I've added some ideas about how to implement my suggestion
+- [ ] I've given this issue the correct labels
+
+### Description of Problem / Inefficiency:
+<!-- Describe what can be improved and how. -->
+
+### Implementation Suggestion:
+<!-- Describe relevant implementation details here. If there are any relevant functions, libraries, or design patterns, mention them here. -->
+
+### Additional Context / Screenshots:
+<!-- Put relevant screenshots, context and **documentation** here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Submit your idea for a new feature!
+title: "Title summarizing new feature"
+labels: feature
+assignees: ""
+
+---
+
+### Checklist
+
+- [ ] I've given this issue a self-descriptive, meaningful title (e.g. *Implement optimization algorithms for shimming*)
+- [ ] I've described the new feature and its expected behaviour
+- [ ] I've described the usage scenario for the new feature
+- [ ] (optional) I've added some ideas about how to implement my suggestion
+- [ ] I've given this issue the correct labels
+
+### Feature Description:
+<!-- Describe the idea for your new feature here. Provide a usage scenario, imagining how the feature would be used (ideally inputs, a sequence of commands, and a desired outcome). Also provide references to any theoretical work to help the reader better understand the feature. -->
+
+### Implementation Suggestion:
+<!-- Describe relevant implementation details here. If there are any relevant functions, libraries, or design patterns, mention them here. -->
+
+### Additional Context / Screenshots:
+<!-- Put relevant screenshots, context and **documentation** here. -->


### PR DESCRIPTION
This PR adds an issue template similar to `shimming-toolbox`. We have 3 types of issues:

1. Bug
2. Enhancement Request
3. Feature Request

Addresses: https://github.com/shimming-toolbox/fsleyes-plugin-shimming-toolbox/issues/13