### PR TITLE
Update installer to integrate with new installer in `shimming-toolbox`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 build/
 dist/
 .vagrant/
+.idea
 dcm2bids.json
 output_*

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,27 @@
 SHELL := /bin/bash
+ST_DIR := $(HOME)/shimming-toolbox
+PYTHON_DIR := python
+CLEAN := false
+
+.SILENT: install
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
 
-install: ## Run 'make install' to install the plugin
-	bash installer/install_conda.sh
+install: ## Run 'make install' to install the plugin [Use flag CLEAN=true for clean install]
+	if [[ $(CLEAN) == true || ! -d $(ST_DIR) ]]; then \
+		echo "Clean install, deleting $(ST_DIR)."; \
+		bash installer/create_st_dir.sh; \
+		bash installer/install_conda.sh; \
+	elif [[ ! -f $(ST_DIR)/$(PYTHON_DIR)/etc/profile.d/conda.sh ]]; then \
+		echo "Conda install not found in $(ST_DIR), installing conda"; \
+		bash installer/install_conda.sh; \
+	else \
+		echo "$(ST_DIR) and conda install found, skipping install of conda"; \
+        fi
+
+	bash installer/create_venv.sh
 	bash installer/install_plugin.sh
 	bash installer/install_shimming_toolbox.sh
 

--- a/installer/create_st_dir.sh
+++ b/installer/create_st_dir.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/utils.sh
+
+ST_DIR="$HOME/shimming-toolbox"
+PYTHON_DIR="python"
+
+mkdir -p "$ST_DIR"
+run rm -rf "$ST_DIR/$PYTHON_DIR"
+run mkdir -p "$ST_DIR/$PYTHON_DIR"

--- a/installer/create_venv.sh
+++ b/installer/create_venv.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/utils.sh
+
+VENV=pst_venv
+ST_DIR="$HOME/shimming-toolbox"
+PYTHON_DIR=python
+cd "$ST_DIR"
+
+print info "Creating new virtual environment in $ST_DIR/$PYTHON_DIR/envs/$VENV"
+
+rm -rf "$ST_DIR/$PYTHON_DIR/envs/$VENV"
+
+# create Python 3.7 venv (for Keras/TF compatibility with Centos7, see issue #2270)
+python/bin/conda create -y -n $VENV python=3.7
+
+if [ "$(uname)" = "Darwin" ]; then
+  # macOS polyfills
+
+  # Linux has `realpath` and `readlink -f`.
+  # BSD has `readlink -f`.
+  # macOS has neither: https://izziswift.com/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac/
+  # even though it *has* the function in its libc: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/realpath.3.html
+  # Someone even wrote a whole C program just for this: https://github.com/harto/realpath-osx/.
+  # https://stackoverflow.com/a/3572105 suggests some bash trickery but it
+  # seems pretty fragile and that it probably doesn't actually expand symlinks.
+  # So here, solve it with python. It's not great either, but since much of
+  # this script already is just calling python at least it's reliable.
+  (command -v realpath >/dev/null) || realpath() {
+    python3 -c 'import sys, os; [print(os.path.realpath(f)) for f in sys.argv[1:]]' "$@"
+  }
+
+
+  # glue over the difference between how BSD and GNU sed work with -i
+  # https://code-examples.net/en/q/56e314
+  sed_i() {
+    sed -i '' "$@"
+  }
+else
+  sed_i() {
+    sed -i "$@"
+  }
+fi
+
+# make sure that there is no conflict with local python install by making $VENV an isolated environment.
+# workaround for https://github.com/conda/conda/issues/7173
+# see also
+# * https://github.com/neuropoly/spinalcordtoolbox/pull/3067
+# * https://github.com/neuropoly/spinalcordtoolbox/issues/3200
+# this needs to be added very early in python's boot process
+# so using sitecustomize.py or even just appending to the file are impossible.
+sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$ST_DIR/$PYTHON_DIR/envs/$VENV/lib/python"*"/site.py"
+
+# activate miniconda
+# shellcheck disable=SC1091
+source python/etc/profile.d/conda.sh
+
+# set +u #disable safeties, for conda is not written to their standard.
+conda activate $VENV
+# set -u # reactivate safeties

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/utils.sh
+
 VENV_ID=1267b18e73341ad94da34474
 VENV=pst_venv_$VENV_ID
 
@@ -9,52 +12,6 @@ TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
 ST_DIR="$HOME/shimming_toolbox"
 PYTHON_DIR="python"
 
-# Print with color
-# @input1: {info, code, error}: type of text
-# rest of inputs: text to print
-function print() {
-  type=$1; shift
-  case "$type" in
-  # Display useful info (green)
-  info)
-    echo -e "\n\033[0;32m${*}\033[0m\n"
-    ;;
-  # To interact with user (no carriage return) (light green)
-  question)
-    echo -e -n "\n\033[0;92m${*}\033[0m"
-    ;;
-  # To display code that is being run in the Terminal (blue)
-  code)
-    echo -e "\n\033[0;34m${*}\033[0m\n"
-    ;;
-  # Warning message (yellow)
-  warning)
-    echo -e "\n\033[0;93m${*}\033[0m\n"
-    ;;
-  # Error message (red)
-  error)
-    echo -e "\n\033[0;31m${*}\033[0m\n"
-    ;;
-  esac
-}
-
-# Elegant exit with colored message
-function die() {
-  print error "$1"
-  exit 1
-}
-
-# Run a command and display it in color. Exit if error.
-# @input: string: command to run
-function run() {
-  ( # this subshell means the 'die' only kills this function and not the whole script;
-    # the caller can decide what to do instead (but with set -e that usually means terminating the whole script)
-    print code "$@"
-    if ! "$@" ; then
-      die "ERROR: Command failed."
-    fi
-  )
-}
 
 mkdir -p "$ST_DIR"
 run rm -rf "$ST_DIR/$PYTHON_DIR"

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -8,7 +8,7 @@ VENV=pst_venv
 rm -rf "$TMP_DIR"
 
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
-ST_DIR="$HOME/shimming_toolbox"
+ST_DIR="$HOME/shimming-toolbox"
 PYTHON_DIR="python"
 
 

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/utils.sh
 
-VENV=pst_venv
+print info "Installing conda in $ST_DIR/$PYTHON_DIR"
 
 rm -rf "$TMP_DIR"
 
@@ -11,16 +11,11 @@ TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
 ST_DIR="$HOME/shimming-toolbox"
 PYTHON_DIR="python"
 
-
-mkdir -p "$ST_DIR"
-run rm -rf "$ST_DIR/$PYTHON_DIR"
-run mkdir -p "$ST_DIR/$PYTHON_DIR"
 cd "$ST_DIR"
 
 set -e
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    apt-get install -y curl
     CONDA_INSTALLER=Miniconda3-latest-Linux-x86_64.sh
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CONDA_INSTALLER=Miniconda3-latest-MacOSX-x86_64.sh
@@ -53,53 +48,5 @@ installConda() {
 }
 
 installConda
-
-# create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-python/bin/conda create -y -n $VENV python=3.7
-
-if [ "$(uname)" = "Darwin" ]; then
-  # macOS polyfills
-
-  # Linux has `realpath` and `readlink -f`.
-  # BSD has `readlink -f`.
-  # macOS has neither: https://izziswift.com/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac/
-  # even though it *has* the function in its libc: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/realpath.3.html
-  # Someone even wrote a whole C program just for this: https://github.com/harto/realpath-osx/.
-  # https://stackoverflow.com/a/3572105 suggests some bash trickery but it
-  # seems pretty fragile and that it probably doesn't actually expand symlinks.
-  # So here, solve it with python. It's not great either, but since much of
-  # this script already is just calling python at least it's reliable.
-  (command -v realpath >/dev/null) || realpath() {
-    python3 -c 'import sys, os; [print(os.path.realpath(f)) for f in sys.argv[1:]]' "$@"
-  }
-
-
-  # glue over the difference between how BSD and GNU sed work with -i
-  # https://code-examples.net/en/q/56e314
-  sed_i() {
-    sed -i '' "$@"
-  }
-else
-  sed_i() {
-    sed -i "$@"
-  }
-fi
-
-# make sure that there is no conflict with local python install by making $VENV an isolated environment.
-# workaround for https://github.com/conda/conda/issues/7173
-# see also
-# * https://github.com/neuropoly/spinalcordtoolbox/pull/3067
-# * https://github.com/neuropoly/spinalcordtoolbox/issues/3200
-# this needs to be added very early in python's boot process
-# so using sitecustomize.py or even just appending to the file are impossible.
-sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$ST_DIR/$PYTHON_DIR/envs/$VENV/lib/python"*"/site.py"
-
-# activate miniconda
-# shellcheck disable=SC1091
-source python/etc/profile.d/conda.sh
-
-# set +u #disable safeties, for conda is not written to their standard.
-conda activate $VENV
-# set -u # reactivate safeties
 
 rm -rf "$TMP_DIR"

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -3,8 +3,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/utils.sh
 
-VENV_ID=1267b18e73341ad94da34474
-VENV=pst_venv_$VENV_ID
+VENV=pst_venv
 
 rm -rf "$TMP_DIR"
 

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -5,8 +5,7 @@ source $SCRIPT_DIR/utils.sh
 
 set -e
 
-VENV_ID=1267b18e73341ad94da34474
-VENV=pst_venv_$VENV_ID
+VENV=pst_venv
 ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 BIN_DIR=bin

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -6,7 +6,7 @@ source $SCRIPT_DIR/utils.sh
 set -e
 
 VENV=pst_venv
-ST_DIR=$HOME/shimming_toolbox
+ST_DIR=$HOME/shimming-toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
 

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -24,8 +24,6 @@ function edit_shellrc() {
         echo
         echo ""
         echo "# FSLEYES_PLUGIN_SHIMMING_TOOLBOX (installed on $(date +%Y-%m-%d\ %H:%M:%S))"
-        echo "$DISPLAY_UPDATE_PATH"
-        echo "export ST_DIR=$ST_DIR"
         echo "alias shimming-toolbox='$ST_DIR/$BIN_DIR/shimming-toolbox.sh'"
         echo ""
       ) >> "$RC_FILE_PATH"
@@ -62,5 +60,3 @@ cp shimming-toolbox.sh $ST_DIR/$BIN_DIR/ # || die "Problem creating launchers!"
 export PATH=$ST_DIR/$BIN_DIR:$PATH
 
 edit_shellrc
-
-print info "Open a new Terminal window to load environment variables, or run: source $RC_FILE_PATH"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -24,7 +24,7 @@ function edit_shellrc() {
         echo
         echo ""
         echo "# FSLEYES_PLUGIN_SHIMMING_TOOLBOX (installed on $(date +%Y-%m-%d\ %H:%M:%S))"
-        echo "alias shimming-toolbox='$ST_DIR/$BIN_DIR/shimming-toolbox.sh'"
+        echo "alias shimming-toolbox='bash $ST_DIR/$BIN_DIR/shimming-toolbox.sh'"
         echo ""
       ) >> "$RC_FILE_PATH"
       else

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -8,6 +8,53 @@ ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
 
+# Print with color
+# @input1: {info, code, error}: type of text
+# rest of inputs: text to print
+function print() {
+  type=$1; shift
+  case "$type" in
+  # Display useful info (green)
+  info)
+    echo -e "\n\033[0;32m${*}\033[0m\n"
+    ;;
+  # To interact with user (no carriage return) (light green)
+  question)
+    echo -e -n "\n\033[0;92m${*}\033[0m"
+    ;;
+  # To display code that is being run in the Terminal (blue)
+  code)
+    echo -e "\n\033[0;34m${*}\033[0m\n"
+    ;;
+  # Warning message (yellow)
+  warning)
+    echo -e "\n\033[0;93m${*}\033[0m\n"
+    ;;
+  # Error message (red)
+  error)
+    echo -e "\n\033[0;31m${*}\033[0m\n"
+    ;;
+  esac
+}
+
+# Elegant exit with colored message
+function die() {
+  print error "$1"
+  exit 1
+}
+
+# Run a command and display it in color. Exit if error.
+# @input: string: command to run
+function run() {
+  ( # this subshell means the 'die' only kills this function and not the whole script;
+    # the caller can decide what to do instead (but with set -e that usually means terminating the whole script)
+    print code "$@"
+    if ! "$@" ; then
+      die "ERROR: Command failed."
+    fi
+  )
+}
+
 
 # Gets the shell rc file path based on the default shell.
 # @output: THE_RC and RC_FILE_PATH vars are modified
@@ -60,17 +107,19 @@ conda activate $VENV
 # set -u
 
 # Install fsleyes
+print info "Installing fsleyes"
 yes | conda install -c conda-forge fsleyes=0.34.2
 
 # Downgrade wxpython version due to bugs
+print info "Downgrading wxpython to 4.0.7"
 yes | conda install -c conda-forge wxpython=4.0.7
 
 # Install fsleyes-plugin-shimming-toolbox
-echo "Installing fsleyes-plugin-shimming-toolbox"
+print info "Installing fsleyes-plugin-shimming-toolbox"
 python -m pip install .
 
 # Create launchers
-echo "Creating launcher for fsleyes-plugin-shimming-toolbox..."
+print info "Creating launcher for fsleyes-plugin-shimming-toolbox..."
 mkdir -p $ST_DIR/$BIN_DIR
 # echo $ST_DIR/python/envs/$VENV/bin/*st_*
 chmod +x shimming-toolbox.sh
@@ -81,4 +130,4 @@ export PATH=$ST_DIR/$BIN_DIR:$PATH
 
 edit_shellrc
 
-echo "Open a new Terminal window to load environment variables, or run: source $RC_FILE_PATH"
+print info "Open a new Terminal window to load environment variables, or run: source $RC_FILE_PATH"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -39,7 +39,7 @@ conda activate $VENV
 
 # Install fsleyes
 print info "Installing fsleyes"
-yes | conda install -c conda-forge fsleyes=0.34.2
+yes | conda install -c conda-forge fsleyes=1.3.3
 
 # Downgrade wxpython version due to bugs
 print info "Downgrading wxpython to 4.0.7"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/utils.sh
+
 set -e
 
 VENV_ID=1267b18e73341ad94da34474
@@ -7,75 +10,6 @@ VENV=pst_venv_$VENV_ID
 ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
-
-# Print with color
-# @input1: {info, code, error}: type of text
-# rest of inputs: text to print
-function print() {
-  type=$1; shift
-  case "$type" in
-  # Display useful info (green)
-  info)
-    echo -e "\n\033[0;32m${*}\033[0m\n"
-    ;;
-  # To interact with user (no carriage return) (light green)
-  question)
-    echo -e -n "\n\033[0;92m${*}\033[0m"
-    ;;
-  # To display code that is being run in the Terminal (blue)
-  code)
-    echo -e "\n\033[0;34m${*}\033[0m\n"
-    ;;
-  # Warning message (yellow)
-  warning)
-    echo -e "\n\033[0;93m${*}\033[0m\n"
-    ;;
-  # Error message (red)
-  error)
-    echo -e "\n\033[0;31m${*}\033[0m\n"
-    ;;
-  esac
-}
-
-# Elegant exit with colored message
-function die() {
-  print error "$1"
-  exit 1
-}
-
-# Run a command and display it in color. Exit if error.
-# @input: string: command to run
-function run() {
-  ( # this subshell means the 'die' only kills this function and not the whole script;
-    # the caller can decide what to do instead (but with set -e that usually means terminating the whole script)
-    print code "$@"
-    if ! "$@" ; then
-      die "ERROR: Command failed."
-    fi
-  )
-}
-
-
-# Gets the shell rc file path based on the default shell.
-# @output: THE_RC and RC_FILE_PATH vars are modified
-function get_shell_rc_path() {
-  if [[ "$SHELL" == *"bash"* ]]; then
-    THE_RC="bash"
-    RC_FILE_PATH="$HOME/.bashrc"
-  elif [[ "$SHELL" == *"/sh"* ]]; then
-    THE_RC="bash"
-    RC_FILE_PATH="$HOME/.bashrc"
-  elif [[ "$SHELL" == *"zsh"* ]]; then
-    THE_RC="bash"
-    RC_FILE_PATH="$HOME/.zshrc"
-  elif [[ "$SHELL" == *"csh"* ]]; then
-    THE_RC="csh"
-    RC_FILE_PATH="$HOME/.cshrc"
-  else
-    find ~/.* -maxdepth 0 -type f
-    die "ERROR: Shell was not recognized: $SHELL"
-  fi
-}
 
 # Define sh files
 get_shell_rc_path

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -5,8 +5,7 @@ source $SCRIPT_DIR/utils.sh
 
 set -e
 
-VENV_ID=1267b18e73341ad94da34474
-VENV=pst_venv_$VENV_ID
+VENV=pst_venv
 ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 BIN_DIR=bin

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -6,7 +6,7 @@ source $SCRIPT_DIR/utils.sh
 set -e
 
 VENV=pst_venv
-ST_DIR=$HOME/shimming_toolbox
+ST_DIR=$HOME/shimming-toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
 

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -11,11 +11,15 @@ cd $ST_DIR
 
 print info "Downloading Shimming-Toolbox"
 
-curl -L https://github.com/shimming-toolbox/shimming-toolbox/archive/refs/heads/master.zip > shimming-toolbox-master.tar.gz
-#gunzip -c shimming-toolbox-master.tar.gz | tar xopf -
-#unzip for now
-unzip -o shimming-toolbox-master.tar.gz
-cd shimming-toolbox-master
+ST_VERSION=f9e272841af5b2798214170b314c342e1174fb79
+
+curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
+
+# Froze a commit, we can select a release later
+# gunzip -c "shimming-toolbox-${ST_VERSION}.tar.gz" | tar xopf -
+# unzip for now, when we use releases we can use the tar and gunzip
+unzip -o "shimming-toolbox-${ST_VERSION}.zip"
+cd "shimming-toolbox-${ST_VERSION}"
 make install
 
 print info "To launch the plugin, load the environment variables then run: shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -57,7 +57,7 @@ source $ST_DIR/$PYTHON_DIR/etc/profile.d/conda.sh
 conda activate $VENV
 # set -u
 
-cd ..
+cd $ST_DIR
 curl -L https://github.com/shimming-toolbox/shimming-toolbox/archive/refs/tags/v0.1-beta.tar.gz > shimming-toolbox-0.1-beta.tar.gz
 gunzip -c shimming-toolbox-0.1-beta.tar.gz | tar xopf -
 cd shimming-toolbox-0.1-beta

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -5,58 +5,17 @@ source $SCRIPT_DIR/utils.sh
 
 set -e
 
-VENV=pst_venv
 ST_DIR=$HOME/shimming-toolbox
-PYTHON_DIR=python
-BIN_DIR=bin
-
-
-# Define sh files
-get_shell_rc_path
-
-# Update PATH variables based on Shell type
-DISPLAY_UPDATE_PATH="export PATH=\"$ST_DIR/$BIN_DIR:\$PATH\""
-
-# Installation text to insert in shell config file
-function edit_shellrc() {
-  # Write text common to all shells
-  if ! grep -Fq "SHIMMINGTOOLBOX (installed on" $RC_FILE_PATH; then
-      (
-        echo
-        echo ""
-        echo "# SHIMMINGTOOLBOX (installed on $(date +%Y-%m-%d\ %H:%M:%S))"
-        echo "$DISPLAY_UPDATE_PATH"
-        echo "export ST_DIR=$ST_DIR"
-        echo ""
-      ) >> "$RC_FILE_PATH"
-      else
-          echo "$RC_FILE_PATH file already updated from previous install, continuing to next step."
-  fi
-}
-
-source $ST_DIR/$PYTHON_DIR/etc/profile.d/conda.sh
-# set +u
-conda activate $VENV
-# set -u
 
 cd $ST_DIR
-curl -L https://github.com/shimming-toolbox/shimming-toolbox/archive/refs/tags/v0.1-beta.tar.gz > shimming-toolbox-0.1-beta.tar.gz
-gunzip -c shimming-toolbox-0.1-beta.tar.gz | tar xopf -
-cd shimming-toolbox-0.1-beta
-cp config/dcm2bids.json $ST_DIR/dcm2bids.json
-python -m pip install .
 
-# Create launchers for Python scripts
-echo "Creating launchers for Python scripts..."
-mkdir -p $ST_DIR/$BIN_DIR
-echo $ST_DIR/python/envs/$VENV/bin/*st_*
-for file in $ST_DIR/python/envs/$VENV/bin/*st_*; do
-  cp "$file" $ST_DIR/$BIN_DIR/ # || die "Problem creating launchers!"
-done
+print info "Downloading Shimming-Toolbox"
 
-# Activate the launchers
-export PATH=$ST_DIR/$BIN_DIR:$PATH
+curl -L https://github.com/shimming-toolbox/shimming-toolbox/archive/refs/heads/master.zip > shimming-toolbox-master.tar.gz
+#gunzip -c shimming-toolbox-master.tar.gz | tar xopf -
+#unzip for now
+unzip -o shimming-toolbox-master.tar.gz
+cd shimming-toolbox-master
+make install
 
-edit_shellrc
-
-echo "Open a new Terminal window to load environment variables, or run: source $RC_FILE_PATH"
+print info "To launch the plugin, load the environment variables then run: shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/utils.sh
+
 set -e
 
 VENV_ID=1267b18e73341ad94da34474
@@ -8,26 +11,6 @@ ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
 
-# Gets the shell rc file path based on the default shell.
-# @output: THE_RC and RC_FILE_PATH vars are modified
-function get_shell_rc_path() {
-  if [[ "$SHELL" == *"bash"* ]]; then
-    THE_RC="bash"
-    RC_FILE_PATH="$HOME/.bashrc"
-  elif [[ "$SHELL" == *"/sh"* ]]; then
-    THE_RC="bash"
-    RC_FILE_PATH="$HOME/.bashrc"
-  elif [[ "$SHELL" == *"zsh"* ]]; then
-    THE_RC="bash"
-    RC_FILE_PATH="$HOME/.zshrc"
-  elif [[ "$SHELL" == *"csh"* ]]; then
-    THE_RC="csh"
-    RC_FILE_PATH="$HOME/.cshrc"
-  else
-    find ~/.* -maxdepth 0 -type f
-    die "ERROR: Shell was not recognized: $SHELL"
-  fi
-}
 
 # Define sh files
 get_shell_rc_path

--- a/installer/utils.sh
+++ b/installer/utils.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Print with color
+# @input1: {info, code, error}: type of text
+# rest of inputs: text to print
+function print() {
+  type=$1; shift
+  case "$type" in
+  # Display useful info (green)
+  info)
+    echo -e "\n\033[0;32m${*}\033[0m\n"
+    ;;
+  # To interact with user (no carriage return) (light green)
+  question)
+    echo -e -n "\n\033[0;92m${*}\033[0m"
+    ;;
+  # To display code that is being run in the Terminal (blue)
+  code)
+    echo -e "\n\033[0;34m${*}\033[0m\n"
+    ;;
+  # Warning message (yellow)
+  warning)
+    echo -e "\n\033[0;93m${*}\033[0m\n"
+    ;;
+  # Error message (red)
+  error)
+    echo -e "\n\033[0;31m${*}\033[0m\n"
+    ;;
+  esac
+}
+
+# Elegant exit with colored message
+function die() {
+  print error "$1"
+  exit 1
+}
+
+# Run a command and display it in color. Exit if error.
+# @input: string: command to run
+function run() {
+  ( # this subshell means the 'die' only kills this function and not the whole script;
+    # the caller can decide what to do instead (but with set -e that usually means terminating the whole script)
+    print code "$@"
+    if ! "$@" ; then
+      die "ERROR: Command failed."
+    fi
+  )
+}
+
+# Gets the shell rc file path based on the default shell.
+# @output: THE_RC and RC_FILE_PATH vars are modified
+function get_shell_rc_path() {
+  if [[ "$SHELL" == *"bash"* ]]; then
+    THE_RC="bash"
+    RC_FILE_PATH="$HOME/.bashrc"
+  elif [[ "$SHELL" == *"/sh"* ]]; then
+    THE_RC="bash"
+    RC_FILE_PATH="$HOME/.bashrc"
+  elif [[ "$SHELL" == *"zsh"* ]]; then
+    THE_RC="bash"
+    RC_FILE_PATH="$HOME/.zshrc"
+  elif [[ "$SHELL" == *"csh"* ]]; then
+    THE_RC="csh"
+    RC_FILE_PATH="$HOME/.cshrc"
+  else
+    find ~/.* -maxdepth 0 -type f
+    die "ERROR: Shell was not recognized: $SHELL"
+  fi
+}

--- a/shimming-toolbox.sh
+++ b/shimming-toolbox.sh
@@ -3,7 +3,7 @@
 set -e
 
 VENV=pst_venv
-ST_DIR=$HOME/shimming_toolbox
+ST_DIR=$HOME/shimming-toolbox
 PYTHON_DIR=python
 
 # conda activate base

--- a/shimming-toolbox.sh
+++ b/shimming-toolbox.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-VENV_ID=1267b18e73341ad94da34474
-VENV=pst_venv_$VENV_ID
+VENV=pst_venv
 ST_DIR=$HOME/shimming_toolbox
 PYTHON_DIR=python
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

## Description
We have created an automated installer for `fsleyes-plugin-shimming-toolbox`, but not for `shimming-toolbox.` I have opened a new pull request to automate the install of `shimming-toolbox`: https://github.com/shimming-toolbox/shimming-toolbox/pull/295. Since `shimming-toolbox` is installed during the install of `fsleyes-plugin-shimming-toolbox`, it is necessary to update our install procedure here.

Update fsleyes to 1.3.3

## Related
Fixes #20 