### PR TITLE
Improve installation

### DIFF
--- a/installer/create_venv.sh
+++ b/installer/create_venv.sh
@@ -13,7 +13,7 @@ print info "Creating new virtual environment in $ST_DIR/$PYTHON_DIR/envs/$VENV"
 rm -rf "$ST_DIR/$PYTHON_DIR/envs/$VENV"
 
 # create Python 3.7 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-python/bin/conda create -y -n $VENV python=3.7
+python/bin/conda create -y -p $ST_DIR/$PYTHON_DIR/envs/$VENV python=3.7
 
 if [ "$(uname)" = "Darwin" ]; then
   # macOS polyfills

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -25,4 +25,5 @@ make install CLEAN=false
 # Copy coil config file in shimming toolbox directory
 cp "${ST_DIR}/shimming-toolbox-${ST_VERSION}/config/coil_config.json" "${ST_DIR}/coil_config.json"
 
-print info "To launch the plugin, load the environment variables then run: shimming-toolbox"
+print info "To launch the plugin, load the environment variables then run:" 
+print info "shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -26,4 +26,4 @@ make install CLEAN=false
 cp "${ST_DIR}/shimming-toolbox-${ST_VERSION}/config/coil_config.json" "${ST_DIR}/coil_config.json"
 
 print info "To launch the plugin, load the environment variables then run:" 
-print code "shimming-toolbox"
+print list "shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -26,4 +26,4 @@ make install CLEAN=false
 cp "${ST_DIR}/shimming-toolbox-${ST_VERSION}/config/coil_config.json" "${ST_DIR}/coil_config.json"
 
 print info "To launch the plugin, load the environment variables then run:" 
-print info "shimming-toolbox"
+print code "shimming-toolbox"

--- a/installer/utils.sh
+++ b/installer/utils.sh
@@ -10,6 +10,10 @@ function print() {
   info)
     echo -e "\n\033[0;32m${*}\033[0m\n"
     ;;
+  # Display useful info as a list (light blue)
+  list)
+    echo -e "\033[0;36m${*}\033[0m\n"
+    ;;
   # To interact with user (no carriage return) (light green)
   question)
     echo -e -n "\n\033[0;92m${*}\033[0m"


### PR DESCRIPTION
## Description
This PR:
- Specifies the full path of the environment instead of relying on the default conda create path. (issue #28)
- Output commands to run on single lines to easily copy them.

## Linked Issues
Fixes #28
