### PR TITLE
Update wxpython to the latest version

### DIFF
--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -247,12 +247,13 @@ class InfoComponent(Component):
         """
         fname_st_logo = os.path.join(DIR, 'img', 'shimming_toolbox_logo.png')
 
-        png = wx.Image(fname_st_logo, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
-        png.SetSize((png.GetWidth() * scale, png.GetHeight() * scale))
+        png = wx.Image(fname_st_logo, wx.BITMAP_TYPE_ANY)
+        png.Rescale(png.GetWidth() * scale, png.GetHeight() * scale, wx.IMAGE_QUALITY_HIGH)
+        bitmap = wx.BitmapFromImage(png)
         logo_image = wx.StaticBitmap(
             parent=self.panel,
             id=-1,
-            bitmap=png,
+            bitmap=bitmap,
             pos=wx.DefaultPosition
         )
         return logo_image
@@ -2017,7 +2018,7 @@ class TextWithButton:
             text_with_button_box.Add(textctrl, 1, wx.ALIGN_LEFT | wx.LEFT, 10)
             if self.required:
                 text_with_button_box.Add(
-                    create_asterisk_icon(self.panel), 0, wx.ALIGN_RIGHT | wx.RIGHT, 7
+                    create_asterisk_icon(self.panel), 0, wx.RIGHT, 7
                 )
 
         return text_with_button_box

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -41,10 +41,6 @@ conda activate $VENV
 print info "Installing fsleyes"
 yes | conda install -c conda-forge fsleyes=1.3.3
 
-# Downgrade wxpython version due to bugs
-print info "Downgrading wxpython to 4.0.7"
-yes | conda install -c conda-forge wxpython=4.0.7
-
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"
 python -m pip install .


### PR DESCRIPTION
## Description
We previously had a line in the installer to downgrade `wxpython` to 4.0.7. This PR aims at removing that line to make the plugin work with `wxpython` 4.1.1. This is relevant since the downgrade adds a significant amount of time to the installation. This is also relevant since it is a necessary step to proceed with a new installer that does not rely on a script.

The main problems that were done/fixed
- Removed the downgrade to `wxpython` 4.0.7 in the installer
- Bitmaps can't change their shape in the newest version. I reshaped it in a `wx.Image` before converting to a Bitmap

TODO
- The dropdown boxes don't display their text fully, this is a problem especially for small dropdown
![Screen Shot 2022-03-30 at 7 29 34 PM](https://user-images.githubusercontent.com/47249340/160947226-77e45f72-6e87-4790-8a48-75363bcdf87a.png)
- Possibly other things

I tested a lot of features but there are probably other problems I have not uncovered


## Linked Issues
Fixes #34
