### PR TITLE
Use mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `ShimmingToolbox` plugin should open as a panel.
 We can use `Docker` to spin up a Linux instance and test our install procedure in a clean
 environment. You will need to install `Docker` on your computer first: https://www.docker.com/products/docker-desktop
 
-To create our testing container, we will first build an image called `fpst:latest`:
+To create our testing container, we will first build an image called `fpst:latest`, if using an M1 mac, add `--platform linux/amd64`:
 ```
 docker build --tag fpst:latest .
 ```
@@ -64,6 +64,14 @@ Altogether:
 ```
 docker rm --force fpst
 docker build --tag fpst:latest .
+docker run --name fpst -dit fpst:latest
+docker exec -it fpst bash
+```
+
+Altogether for M1 macs:
+```
+docker rm --force fpst
+docker build --platform linux/amd64 --tag fpst:latest .
 docker run --name fpst -dit fpst:latest
 docker exec -it fpst bash
 ```
@@ -119,7 +127,7 @@ You can open a terminal from this GUI, and run `FSLeyes` by:
 
 ```
 cd src/fsleyes-plugin/shimming-toolbox/
-make run
+shimming-toolbox
 ```
 
 #### Vagrant Tips

--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -55,7 +55,7 @@ play_icon = wx.Bitmap(os.path.join(DIR, 'img', 'play.png'), wx.BITMAP_TYPE_PNG)
 rtd_logo = wx.Bitmap(os.path.join(DIR, 'img', 'RTD.png'), wx.BITMAP_TYPE_PNG)
 # Load ShimmingToolbox logo saved as a png image, rescale it, and return it as a wx.Bitmap image.
 st_logo = wx.Image(os.path.join(DIR, 'img', 'shimming_toolbox_logo.png'), wx.BITMAP_TYPE_PNG)
-st_logo.Rescale(st_logo.GetWidth() * 0.2, st_logo.GetHeight() * 0.2, wx.IMAGE_QUALITY_HIGH)
+st_logo.Rescale(int(st_logo.GetWidth() * 0.2), int(st_logo.GetHeight() * 0.2), wx.IMAGE_QUALITY_HIGH)
 st_logo = st_logo.ConvertToBitmap()
 
 

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -16,9 +16,9 @@ cd "$ST_DIR"
 set -e
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    CONDA_INSTALLER=Miniconda3-py37_4.11.0-Linux-x86_64.sh
+    CONDA_INSTALLER=Mambaforge-Linux-x86_64.sh
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CONDA_INSTALLER=Miniconda3-py37_4.11.0-MacOSX-x86_64.sh
+    CONDA_INSTALLER=Mambaforge-Darwin-x86_64.sh
 elif [[ "$OSTYPE" == "cygwin" ]]; then
     # POSIX compatibility layer and Linux environment emulation for Windows
     echo "Invalid operating system"
@@ -38,10 +38,10 @@ else
     exit 1
 fi
 
-CONDA_INSTALLER_URL=https://repo.anaconda.com/miniconda/$CONDA_INSTALLER
+CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/latest/download/"$CONDA_INSTALLER"
 
 installConda() {
-    curl --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER
+    curl -L --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER
     run bash "$TMP_DIR/$CONDA_INSTALLER" -p "$ST_DIR/$PYTHON_DIR" -b -f
     # export PATH=$HOME/miniconda3/bin:$PATH
     # source $HOME/miniconda3/bin/activate

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -35,7 +35,7 @@ source $ST_DIR/$PYTHON_DIR/bin/activate
 
 # Install fsleyes
 print info "Installing fsleyes"
-"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.4.6
+"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.4.6 python=3.9
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -35,7 +35,7 @@ source $ST_DIR/$PYTHON_DIR/bin/activate
 
 # Install fsleyes
 print info "Installing fsleyes"
-"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.3.3
+"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.4.6
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -35,7 +35,7 @@ source $ST_DIR/$PYTHON_DIR/bin/activate
 
 # Install fsleyes
 print info "Installing fsleyes"
-"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.4.6 python=3.9
+"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.4.6 fsleyes-props=1.7.3 python=3.9
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -35,7 +35,7 @@ source $ST_DIR/$PYTHON_DIR/bin/activate
 
 # Install fsleyes
 print info "Installing fsleyes"
-"$ST_DIR"/"$PYTHON_DIR"/bin/conda install -y -c conda-forge fsleyes=1.3.3
+"$ST_DIR"/"$PYTHON_DIR"/bin/mamba install -y -c conda-forge fsleyes=1.3.3
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION=01f29ae99d33237efdbf6284a24875ba01ac279d
+ST_VERSION=be55514b67a9750b790be7b2aad502523b6fbcf1
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION=be55514b67a9750b790be7b2aad502523b6fbcf1
+ST_VERSION=311d177ef17551f8df401cdcf936f051cade145f
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION=b42be55e92299fcda7f588cb3be05f59f1127ada
+ST_VERSION=01f29ae99d33237efdbf6284a24875ba01ac279d
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -1,4 +1,4 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/utils.sh


### PR DESCRIPTION
## Description
On Linux/WSL, when downgrading wxpython, there's a long wait
anywhere from 10 minutes to over an hour depending on the
computer installing the plugin.

Even if we fix wx, conda has a SAT-solver lurking inside of it
which almost at random, due to one version change or missing build
of some dependency package, can suddenly become extremely slow.

mamba has a smarter solver that takes a fraction of the time. This PR:

- Uses mamba to resolve the long solver time.
- Updates to using Python 3.9 and FSLeyes 1.4.6

See https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html
See https://github.com/conda/conda/issues/8051

## Testing

git clone https://github.com/shimming-toolbox/fsleyes-plugin-shimming-toolbox.git
cd fsleyes-plugin-shimming-toolbox
git checkout ng/faster-install
make install CLEAN=true

## Linked Issues
Fixes https://github.com/shimming-toolbox/shimming-toolbox/issues/369#issuecomment-1083589939
