### PR TITLE
Switch to using miniforge.

### DIFF
--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -16,9 +16,9 @@ cd "$ST_DIR"
 set -e
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    CONDA_INSTALLER=Miniconda3-py37_4.11.0-Linux-x86_64.sh
+    CONDA_INSTALLER=Miniforge3-Linux-x86_64.sh
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CONDA_INSTALLER=Miniconda3-py37_4.11.0-MacOSX-x86_64.sh
+    CONDA_INSTALLER=Miniforge3-MacOSX-x86_64.sh
 elif [[ "$OSTYPE" == "cygwin" ]]; then
     # POSIX compatibility layer and Linux environment emulation for Windows
     echo "Invalid operating system"
@@ -38,10 +38,10 @@ else
     exit 1
 fi
 
-CONDA_INSTALLER_URL=https://repo.anaconda.com/miniconda/$CONDA_INSTALLER
+CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/latest/download/$CONDA_INSTALLER
 
 installConda() {
-    curl --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER
+    curl -L --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER
     run bash "$TMP_DIR/$CONDA_INSTALLER" -p "$ST_DIR/$PYTHON_DIR" -b -f
     # export PATH=$HOME/miniconda3/bin:$PATH
     # source $HOME/miniconda3/bin/activate


### PR DESCRIPTION


## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description

This is conda pointed at conda-forge and *not* at anaconda's official
repos; using this hopefully avoids the long solver times that sometimes
appear when installing fsleyes, because fsleyes is built (and tested?)
only against conda-forge's packages.

The problem line is

> Solving environment: failed with initial frozen solve. Retrying with flexible solve.

and then it takes a long time, over 4 hours sometimes.

A couple months ago this was only affecting Linux, but as of this weekend macOS got bitten too.
Some dependency must have shifted in the macOS recently.

<details><summary>Logs</summary>

```
$ make install
[....]
Installing fsleyes

Collecting package metadata (current_repodata.json): done
Solving environment: failed with initial frozen solve. Retrying with flexible solve.
Collecting package metadata (repodata.json): | WARNING conda.models.version:get_matcher(540): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 2.*, but conda is ignoring the .* and treating it as 2
- WARNING conda.models.version:get_matcher(540): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.6.*, but conda is ignoring the .* and treating it as 3.6
| WARNING conda.models.version:get_matcher(540): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 1.*, but conda is ignoring the .* and treating it as 1
done
Solving environment: failed with initial frozen solve. Retrying with flexible solve.
Solving environment: done


==> WARNING: A newer version of conda exists. <==
  current version: 4.11.0
  latest version: 4.12.0

Please update conda by running

    $ conda update -n base -c defaults conda



## Package Plan ##

  environment location: /home/GRAMES.POLYMTL.CA/p115628/shimming-toolbox/python

  added / updated specs:
    - fsleyes=1.3.3


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    _libgcc_mutex-0.1          |      conda_forge           3 KB  conda-forge
    _openmp_mutex-4.5          |            2_gnu          23 KB  conda-forge
    alabaster-0.7.12           |             py_0          15 KB  conda-forge
    alsa-lib-1.2.6.1           |       h7f98852_0         578 KB  conda-forge
    argon2-cffi-21.3.0         |     pyhd8ed1ab_0          15 KB  conda-forge
    argon2-cffi-bindings-21.2.0|   py37h540881e_2          34 KB  conda-forge
    atk-1.0-2.36.0             |       h3371d22_4         560 KB  conda-forge
    attrs-21.4.0               |     pyhd8ed1ab_0          49 KB  conda-forge
    babel-2.10.1               |     pyhd8ed1ab_0         6.7 MB  conda-forge
    backcall-0.2.0             |     pyh9f0ad1d_0          13 KB  conda-forge
    backports-1.0              |             py_2           4 KB  conda-forge
    backports.functools_lru_cache-1.6.4|     pyhd8ed1ab_0           9 KB  conda-forge
    beautifulsoup4-4.11.1      |     pyha770c72_0          96 KB  conda-forge
    bleach-5.0.0               |     pyhd8ed1ab_0         123 KB  conda-forge
    brotli-1.0.9               |       h166bdaf_7          18 KB  conda-forge
    brotli-bin-1.0.9           |       h166bdaf_7          19 KB  conda-forge
    brotlipy-0.7.0             |py37h540881e_1004         342 KB  conda-forge
    bzip2-1.0.8                |       h7f98852_4         484 KB  conda-forge
    ca-certificates-2022.5.18  |       ha878542_0         144 KB  conda-forge
    cached-property-1.5.2      |       hd8ed1ab_1           4 KB  conda-forge
    cached_property-1.5.2      |     pyha770c72_1          11 KB  conda-forge
    cairo-1.16.0               |    ha61ee94_1011         1.5 MB  conda-forge
    certifi-2022.5.18          |   py37h89c1867_0         150 KB  conda-forge
    cffi-1.15.0                |   py37h036bc23_0         225 KB  conda-forge
    charset-normalizer-2.0.12  |     pyhd8ed1ab_0          35 KB  conda-forge
    click-8.1.3                |   py37h89c1867_0         145 KB  conda-forge
    colorama-0.4.4             |     pyh9f0ad1d_0          18 KB  conda-forge
    commonmark-0.9.1           |             py_0          46 KB  conda-forge
    conda-4.12.0               |   py37h89c1867_0         1.0 MB  conda-forge
    conda-content-trust-0.1.3  |     pyhd8ed1ab_0          54 KB  conda-forge
    conda-package-handling-1.8.1|   py37h540881e_1         1.0 MB  conda-forge
    cryptography-36.0.2        |   py37h38fbfac_1         1.6 MB  conda-forge
    cycler-0.11.0              |     pyhd8ed1ab_0          10 KB  conda-forge
    dataclasses-0.8            |     pyhc8e2a94_3          10 KB  conda-forge
    dcm2niix-1.0.20211006      |       h4bd325d_0         212 KB  conda-forge
    debugpy-1.6.0              |   py37hd23a5d3_0         2.0 MB  conda-forge
    decorator-5.1.1            |     pyhd8ed1ab_0          12 KB  conda-forge
    defusedxml-0.7.1           |     pyhd8ed1ab_0          23 KB  conda-forge
    dill-0.3.4                 |     pyhd8ed1ab_0          62 KB  conda-forge
    docutils-0.17.1            |   py37h89c1867_2         759 KB  conda-forge
    elfutils-0.186             |       he364ef2_0         1.7 MB  conda-forge
    entrypoints-0.4            |     pyhd8ed1ab_0           9 KB  conda-forge
    file-tree-0.7.2            |     pyhd8ed1ab_0          28 KB  conda-forge
    file-tree-fsl-0.2.1        |     pyhd8ed1ab_0          14 KB  conda-forge
    flit-core-3.7.1            |     pyhd8ed1ab_0          44 KB  conda-forge
    font-ttf-dejavu-sans-mono-2.37|       hab24e00_0         388 KB  conda-forge
    font-ttf-inconsolata-3.000 |       h77eed37_0          94 KB  conda-forge
    font-ttf-source-code-pro-2.038|       h77eed37_0         684 KB  conda-forge
    font-ttf-ubuntu-0.83       |       hab24e00_0         1.9 MB  conda-forge
    fontconfig-2.14.0          |       h8e229c2_0         305 KB  conda-forge
    fonts-conda-ecosystem-1    |                0           4 KB  conda-forge
    fonts-conda-forge-1        |                0           4 KB  conda-forge
    fonttools-4.33.3           |   py37h540881e_0         1.6 MB  conda-forge
    fribidi-1.0.10             |       h36c2ea0_0         112 KB  conda-forge
    fsleyes-1.3.3              |   py37h89c1867_1        29.3 MB  conda-forge
    fsleyes-props-1.7.3        |     pyhd8ed1ab_0          90 KB  conda-forge
    fsleyes-widgets-0.12.3     |     pyhd8ed1ab_0         575 KB  conda-forge
    fslpy-3.9.1                |     pyhd8ed1ab_0         3.7 MB  conda-forge
    future-0.18.2              |   py37h89c1867_5         713 KB  conda-forge
    gdk-pixbuf-2.42.8          |       hff1cb4f_0         595 KB  conda-forge
    glib-2.70.2                |       h780b84a_4         430 KB  conda-forge
    glib-tools-2.70.2          |       h780b84a_4         106 KB  conda-forge
    gnutls-3.6.13              |       h85f3911_1         2.0 MB  conda-forge
    graphite2-1.3.13           |    h58526e2_1001         102 KB  conda-forge
    gst-plugins-base-1.20.2    |       hf6a322e_1         2.8 MB  conda-forge
    gstreamer-1.20.2           |       hd4edc92_1         2.0 MB  conda-forge
    gtk2-2.24.33               |       h90689f9_2         7.4 MB  conda-forge
    h5py-3.6.0                 |nompi_py37hd308b1e_100         1.3 MB  conda-forge
    harfbuzz-4.2.1             |       hf9f4e7c_0         2.1 MB  conda-forge
    hdf5-1.12.1                |nompi_h2386368_104         3.5 MB  conda-forge
    icu-70.1                   |       h27087fc_0        13.5 MB  conda-forge
    idna-3.3                   |     pyhd8ed1ab_0          55 KB  conda-forge
    imagesize-1.3.0            |     pyhd8ed1ab_0           9 KB  conda-forge
    importlib-metadata-4.11.3  |   py37h89c1867_1          33 KB  conda-forge
    importlib_resources-5.7.1  |     pyhd8ed1ab_1          22 KB  conda-forge
    indexed_gzip-1.6.13        |   py37h7dba1dc_0         586 KB  conda-forge
    ipykernel-6.13.0           |   py37h25bab4e_0         185 KB  conda-forge
    ipython-7.33.0             |   py37h89c1867_0         1.1 MB  conda-forge
    ipython_genutils-0.2.0     |             py_1          21 KB  conda-forge
    isodate-0.6.1              |     pyhd8ed1ab_0          28 KB  conda-forge
    jedi-0.18.1                |   py37h89c1867_1        1008 KB  conda-forge
    jinja2-3.1.2               |     pyhd8ed1ab_0          99 KB  conda-forge
    jpeg-9e                    |       h166bdaf_1         268 KB  conda-forge
    jsonschema-4.5.1           |     pyhd8ed1ab_0          57 KB  conda-forge
    jupyter_client-7.3.1       |     pyhd8ed1ab_0          90 KB  conda-forge
    jupyter_core-4.10.0        |   py37h89c1867_0          81 KB  conda-forge
    jupyterlab_pygments-0.2.2  |     pyhd8ed1ab_0          17 KB  conda-forge
    kiwisolver-1.4.2           |   py37h7cecad7_1          73 KB  conda-forge
    ld_impl_linux-64-2.36.1    |       hea4e1c9_2         667 KB  conda-forge
    libarchive-3.5.2           |       hb890918_2         1.6 MB  conda-forge
    libblas-3.9.0              |14_linux64_openblas          12 KB  conda-forge
    libbrotlicommon-1.0.9      |       h166bdaf_7          65 KB  conda-forge
    libbrotlidec-1.0.9         |       h166bdaf_7          33 KB  conda-forge
    libbrotlienc-1.0.9         |       h166bdaf_7         287 KB  conda-forge
    libcblas-3.9.0             |14_linux64_openblas          12 KB  conda-forge
    libcurl-7.83.1             |       h7bff187_0         342 KB  conda-forge
    libdrm-2.4.109             |       h7f98852_0         284 KB  conda-forge
    libffi-3.4.2               |       h7f98852_5          57 KB  conda-forge
    libgcc-ng-12.1.0           |      h8d9b700_16         940 KB  conda-forge
    libgfortran-ng-12.1.0      |      h69a702a_16          23 KB  conda-forge
    libgfortran5-12.1.0        |      hdcd56e2_16         1.8 MB  conda-forge
    libglu-9.0.0               |    he1b5a44_1001         413 KB  conda-forge
    libgomp-12.1.0             |      h8d9b700_16         459 KB  conda-forge
    liblapack-3.9.0            |14_linux64_openblas          12 KB  conda-forge
    libmicrohttpd-0.9.75       |       h7f98852_0         219 KB  conda-forge
    libnsl-2.0.0               |       h7f98852_0          31 KB  conda-forge
    libogg-1.3.4               |       h7f98852_1         206 KB  conda-forge
    libopenblas-0.3.20         |pthreads_h78a6416_0        10.1 MB  conda-forge
    libopus-1.3.1              |       h7f98852_1         255 KB  conda-forge
    libpciaccess-0.16          |       h516909a_0          37 KB  conda-forge
    libsodium-1.0.18           |       h36c2ea0_1         366 KB  conda-forge
    libspatialindex-1.9.3      |       h9c3ff4c_4         4.6 MB  conda-forge
    libstdcxx-ng-12.1.0        |      ha89aaad_16         4.3 MB  conda-forge
    libuuid-2.32.1             |    h7f98852_1000          28 KB  conda-forge
    libvorbis-1.3.7            |       h9c3ff4c_0         280 KB  conda-forge
    libxml2-2.9.14             |       h22db469_0         770 KB  conda-forge
    libzlib-1.2.11             |    h166bdaf_1014          60 KB  conda-forge
    lzo-2.10                   |    h516909a_1000         314 KB  conda-forge
    markupsafe-2.1.1           |   py37h540881e_1          22 KB  conda-forge
    matplotlib-base-3.5.2      |   py37hc347a89_0         7.3 MB  conda-forge
    matplotlib-inline-0.1.3    |     pyhd8ed1ab_0          11 KB  conda-forge
    mesalib-21.2.5             |       h0e4506f_3         4.1 MB  conda-forge
    mistune-0.8.4              |py37h5e8e339_1005          54 KB  conda-forge
    munkres-1.1.4              |     pyh9f0ad1d_0          12 KB  conda-forge
    nbclient-0.6.3             |     pyhd8ed1ab_0          65 KB  conda-forge
    nbconvert-6.5.0            |     pyhd8ed1ab_0           6 KB  conda-forge
    nbconvert-core-6.5.0       |     pyhd8ed1ab_0         425 KB  conda-forge
    nbconvert-pandoc-6.5.0     |     pyhd8ed1ab_0           4 KB  conda-forge
    nbformat-5.4.0             |     pyhd8ed1ab_0         104 KB  conda-forge
    nest-asyncio-1.5.5         |     pyhd8ed1ab_0           9 KB  conda-forge
    nettle-3.6                 |       he412f7d_0         6.5 MB  conda-forge
    nibabel-3.2.2              |     pyhd8ed1ab_0         2.7 MB  conda-forge
    notebook-6.4.11            |     pyha770c72_0         6.3 MB  conda-forge
    numpy-1.21.6               |   py37h976b520_0         6.1 MB  conda-forge
    openssl-1.1.1o             |       h166bdaf_0         2.1 MB  conda-forge
    packaging-21.3             |     pyhd8ed1ab_0          36 KB  conda-forge
    pandas-1.3.5               |   py37he8f5f7f_0        12.7 MB  conda-forge
    pandoc-2.18                |       ha770c72_0        12.5 MB  conda-forge
    pandocfilters-1.5.0        |     pyhd8ed1ab_0          11 KB  conda-forge
    pango-1.50.7               |       hbd2fdc8_0         456 KB  conda-forge
    parse-1.19.0               |     pyh44b312d_0          22 KB  conda-forge
    parso-0.8.3                |     pyhd8ed1ab_0          69 KB  conda-forge
    pathlib2-2.3.7.post1       |   py37h89c1867_1          36 KB  conda-forge
    pexpect-4.8.0              |     pyh9f0ad1d_2          47 KB  conda-forge
    pickleshare-0.7.5          |          py_1003           9 KB  conda-forge
    pillow-9.1.1               |   py37h44f0d7a_0        44.9 MB  conda-forge
    pip-22.1                   |     pyhd8ed1ab_0         1.6 MB  conda-forge
    pixman-0.40.0              |       h36c2ea0_0         627 KB  conda-forge
    progressbar2-4.0.0         |     pyhd8ed1ab_0          27 KB  conda-forge
    prometheus_client-0.14.1   |     pyhd8ed1ab_0          49 KB  conda-forge
    prompt-toolkit-3.0.29      |     pyha770c72_0         252 KB  conda-forge
    psutil-5.9.0               |   py37h540881e_1         342 KB  conda-forge
    ptyprocess-0.7.0           |     pyhd3deb0d_0          16 KB  conda-forge
    pycosat-0.6.3              |py37h540881e_1010         107 KB  conda-forge
    pycparser-2.21             |     pyhd8ed1ab_0         100 KB  conda-forge
    pydicom-2.3.0              |     pyh6c4a22f_0         1.4 MB  conda-forge
    pygments-2.12.0            |     pyhd8ed1ab_0         817 KB  conda-forge
    pyopengl-3.1.6             |     pyhd8ed1ab_1         867 KB  conda-forge
    pyopenssl-22.0.0           |     pyhd8ed1ab_0          49 KB  conda-forge
    pyparsing-2.4.7            |     pyhd8ed1ab_1          60 KB  conda-forge
    pypubsub-4.0.3             |             py_0          44 KB  conda-forge
    pyrsistent-0.18.1          |   py37h540881e_1          91 KB  conda-forge
    pysocks-1.7.1              |   py37h89c1867_5          28 KB  conda-forge
    python-3.7.12              |hb7a2778_100_cpython        57.3 MB  conda-forge
    python-fastjsonschema-2.15.3|     pyhd8ed1ab_0         243 KB  conda-forge
    python-utils-3.2.2         |     pyhd8ed1ab_0          21 KB  conda-forge
    python_abi-3.7             |          2_cp37m           4 KB  conda-forge
    pytz-2022.1                |     pyhd8ed1ab_0         242 KB  conda-forge
    pyzmq-23.0.0               |   py37h0c0c2a8_0         474 KB  conda-forge
    readline-8.1               |       h46c0cb4_0         295 KB  conda-forge
    requests-2.27.1            |     pyhd8ed1ab_0          53 KB  conda-forge
    rich-12.4.1                |     pyhd8ed1ab_0         164 KB  conda-forge
    rtree-1.0.0                |   py37h0b55af0_1          49 KB  conda-forge
    ruamel_yaml-0.15.80        |py37h5e8e339_1006         270 KB  conda-forge
    scipy-1.7.3                |   py37hf2a6cf1_0        21.8 MB  conda-forge
    send2trash-1.8.0           |     pyhd8ed1ab_0          17 KB  conda-forge
    setuptools-59.8.0          |   py37h89c1867_1         1.0 MB  conda-forge
    six-1.16.0                 |     pyh6c4a22f_0          14 KB  conda-forge
    snowballstemmer-2.2.0      |     pyhd8ed1ab_0          57 KB  conda-forge
    soupsieve-2.3.1            |     pyhd8ed1ab_0          33 KB  conda-forge
    sphinx-4.5.0               |     pyh6c4a22f_0         1.6 MB  conda-forge
    sphinx_rtd_theme-1.0.0     |     pyhd8ed1ab_0         2.7 MB  conda-forge
    sphinxcontrib-applehelp-1.0.2|             py_0          28 KB  conda-forge
    sphinxcontrib-devhelp-1.0.2|             py_0          22 KB  conda-forge
    sphinxcontrib-htmlhelp-2.0.0|     pyhd8ed1ab_0          31 KB  conda-forge
    sphinxcontrib-jsmath-1.0.1 |             py_0           7 KB  conda-forge
    sphinxcontrib-qthelp-1.0.3 |             py_0          25 KB  conda-forge
    sphinxcontrib-serializinghtml-1.1.5|     pyhd8ed1ab_2          27 KB  conda-forge
    sqlite-3.38.5              |       h4ff8645_0         1.5 MB  conda-forge
    terminado-0.15.0           |   py37h89c1867_0          28 KB  conda-forge
    textual-0.1.18             |     pyhd8ed1ab_0          66 KB  conda-forge
    tinycss2-1.1.1             |     pyhd8ed1ab_0          23 KB  conda-forge
    tk-8.6.12                  |       h27826a3_0         3.3 MB  conda-forge
    tornado-6.1                |   py37h540881e_3         646 KB  conda-forge
    traitlets-5.2.1.post0      |     pyhd8ed1ab_0          85 KB  conda-forge
    trimesh-3.12.0             |     pyh6c4a22f_0         518 KB  conda-forge
    typing-extensions-3.10.0.2 |       hd8ed1ab_0           8 KB  conda-forge
    typing_extensions-3.10.0.2 |     pyha770c72_0          28 KB  conda-forge
    unicodedata2-14.0.0        |   py37h540881e_1         496 KB  conda-forge
    wcwidth-0.2.5              |     pyh9f0ad1d_2          33 KB  conda-forge
    webencodings-0.5.1         |             py_1          12 KB  conda-forge
    wheel-0.37.1               |     pyhd8ed1ab_0          31 KB  conda-forge
    wxnatpy-0.4.0              |     pyhd8ed1ab_0          21 KB  conda-forge
    wxpython-4.1.1             |   py37hecb6014_7        21.0 MB  conda-forge
    xarray-0.20.2              |     pyhd8ed1ab_0         628 KB  conda-forge
    xnat-0.4.2                 |     pyhd8ed1ab_0          64 KB  conda-forge
    xorg-damageproto-1.2.1     |    h7f98852_1002          25 KB  conda-forge
    xorg-fixesproto-5.0        |    h7f98852_1002           9 KB  conda-forge
    xorg-glproto-1.4.17        |    h7f98852_1002          21 KB  conda-forge
    xorg-kbproto-1.0.7         |    h7f98852_1002          27 KB  conda-forge
    xorg-libice-1.0.10         |       h7f98852_0          58 KB  conda-forge
    xorg-libsm-1.2.3           |    hd9c2040_1000          26 KB  conda-forge
    xorg-libx11-1.7.2          |       h7f98852_0         941 KB  conda-forge
    xorg-libxdamage-1.1.5      |       h7f98852_1          12 KB  conda-forge
    xorg-libxext-1.3.4         |       h7f98852_1          54 KB  conda-forge
    xorg-libxfixes-5.0.3       |    h7f98852_1004          18 KB  conda-forge
    xorg-libxrandr-1.5.2       |       h7f98852_1          29 KB  conda-forge
    xorg-libxrender-0.9.10     |    h7f98852_1003          32 KB  conda-forge
    xorg-randrproto-1.5.0      |    h7f98852_1001          32 KB  conda-forge
    xorg-renderproto-0.11.1    |    h7f98852_1002           9 KB  conda-forge
    xorg-util-macros-1.19.3    |       h7f98852_0          51 KB  conda-forge
    xorg-xextproto-7.3.0       |    h7f98852_1002          28 KB  conda-forge
    xorg-xf86vidmodeproto-2.3.1|    h7f98852_1002          23 KB  conda-forge
    xorg-xproto-7.0.31         |    h7f98852_1007          73 KB  conda-forge
    xz-5.2.5                   |       h516909a_1         343 KB  conda-forge
    yaml-0.2.5                 |       h7f98852_2          87 KB  conda-forge
    zeromq-4.3.4               |       h9c3ff4c_1         351 KB  conda-forge
    zlib-1.2.11                |    h166bdaf_1014          88 KB  conda-forge
    zstd-1.5.2                 |       h8a70e8d_1         452 KB  conda-forge
    ------------------------------------------------------------
                                           Total:       357.6 MB

The following NEW packages will be INSTALLED:

  alabaster          conda-forge/noarch::alabaster-0.7.12-py_0
  alsa-lib           conda-forge/linux-64::alsa-lib-1.2.6.1-h7f98852_0
  argon2-cffi        conda-forge/noarch::argon2-cffi-21.3.0-pyhd8ed1ab_0
  argon2-cffi-bindi~ conda-forge/linux-64::argon2-cffi-bindings-21.2.0-py37h540881e_2
  atk-1.0            conda-forge/linux-64::atk-1.0-2.36.0-h3371d22_4
  attrs              conda-forge/noarch::attrs-21.4.0-pyhd8ed1ab_0
  babel              conda-forge/noarch::babel-2.10.1-pyhd8ed1ab_0
  backcall           conda-forge/noarch::backcall-0.2.0-pyh9f0ad1d_0
  backports          conda-forge/noarch::backports-1.0-py_2
  backports.functoo~ conda-forge/noarch::backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0
  beautifulsoup4     conda-forge/noarch::beautifulsoup4-4.11.1-pyha770c72_0
  bleach             conda-forge/noarch::bleach-5.0.0-pyhd8ed1ab_0
  brotli             conda-forge/linux-64::brotli-1.0.9-h166bdaf_7
  brotli-bin         conda-forge/linux-64::brotli-bin-1.0.9-h166bdaf_7
  bzip2              conda-forge/linux-64::bzip2-1.0.8-h7f98852_4
  c-ares             conda-forge/linux-64::c-ares-1.18.1-h7f98852_0
  cached-property    conda-forge/noarch::cached-property-1.5.2-hd8ed1ab_1
  cached_property    conda-forge/noarch::cached_property-1.5.2-pyha770c72_1
  cairo              conda-forge/linux-64::cairo-1.16.0-ha61ee94_1011
  click              conda-forge/linux-64::click-8.1.3-py37h89c1867_0
  colorama           conda-forge/noarch::colorama-0.4.4-pyh9f0ad1d_0
  commonmark         conda-forge/noarch::commonmark-0.9.1-py_0
  cycler             conda-forge/noarch::cycler-0.11.0-pyhd8ed1ab_0
  dataclasses        conda-forge/noarch::dataclasses-0.8-pyhc8e2a94_3
  dcm2niix           conda-forge/linux-64::dcm2niix-1.0.20211006-h4bd325d_0
  debugpy            conda-forge/linux-64::debugpy-1.6.0-py37hd23a5d3_0
  decorator          conda-forge/noarch::decorator-5.1.1-pyhd8ed1ab_0
  defusedxml         conda-forge/noarch::defusedxml-0.7.1-pyhd8ed1ab_0
  dill               conda-forge/noarch::dill-0.3.4-pyhd8ed1ab_0
  docutils           conda-forge/linux-64::docutils-0.17.1-py37h89c1867_2
  elfutils           conda-forge/linux-64::elfutils-0.186-he364ef2_0
  entrypoints        conda-forge/noarch::entrypoints-0.4-pyhd8ed1ab_0
  expat              conda-forge/linux-64::expat-2.4.8-h27087fc_0
  file-tree          conda-forge/noarch::file-tree-0.7.2-pyhd8ed1ab_0
  file-tree-fsl      conda-forge/noarch::file-tree-fsl-0.2.1-pyhd8ed1ab_0
  flit-core          conda-forge/noarch::flit-core-3.7.1-pyhd8ed1ab_0
  font-ttf-dejavu-s~ conda-forge/noarch::font-ttf-dejavu-sans-mono-2.37-hab24e00_0
  font-ttf-inconsol~ conda-forge/noarch::font-ttf-inconsolata-3.000-h77eed37_0
  font-ttf-source-c~ conda-forge/noarch::font-ttf-source-code-pro-2.038-h77eed37_0
  font-ttf-ubuntu    conda-forge/noarch::font-ttf-ubuntu-0.83-hab24e00_0
  fontconfig         conda-forge/linux-64::fontconfig-2.14.0-h8e229c2_0
  fonts-conda-ecosy~ conda-forge/noarch::fonts-conda-ecosystem-1-0
  fonts-conda-forge  conda-forge/noarch::fonts-conda-forge-1-0
  fonttools          conda-forge/linux-64::fonttools-4.33.3-py37h540881e_0
  freetype           conda-forge/linux-64::freetype-2.10.4-h0708190_1
  fribidi            conda-forge/linux-64::fribidi-1.0.10-h36c2ea0_0
  fsleyes            conda-forge/linux-64::fsleyes-1.3.3-py37h89c1867_1
  fsleyes-props      conda-forge/noarch::fsleyes-props-1.7.3-pyhd8ed1ab_0
  fsleyes-widgets    conda-forge/noarch::fsleyes-widgets-0.12.3-pyhd8ed1ab_0
  fslpy              conda-forge/noarch::fslpy-3.9.1-pyhd8ed1ab_0
  future             conda-forge/linux-64::future-0.18.2-py37h89c1867_5
  gdk-pixbuf         conda-forge/linux-64::gdk-pixbuf-2.42.8-hff1cb4f_0
  gettext            conda-forge/linux-64::gettext-0.19.8.1-h73d1719_1008
  giflib             conda-forge/linux-64::giflib-5.2.1-h36c2ea0_2
  glib               conda-forge/linux-64::glib-2.70.2-h780b84a_4
  glib-tools         conda-forge/linux-64::glib-tools-2.70.2-h780b84a_4
  gnutls             conda-forge/linux-64::gnutls-3.6.13-h85f3911_1
  graphite2          conda-forge/linux-64::graphite2-1.3.13-h58526e2_1001
  gst-plugins-base   conda-forge/linux-64::gst-plugins-base-1.20.2-hf6a322e_1
  gstreamer          conda-forge/linux-64::gstreamer-1.20.2-hd4edc92_1
  gtk2               conda-forge/linux-64::gtk2-2.24.33-h90689f9_2
  h5py               conda-forge/linux-64::h5py-3.6.0-nompi_py37hd308b1e_100
  harfbuzz           conda-forge/linux-64::harfbuzz-4.2.1-hf9f4e7c_0
  hdf5               conda-forge/linux-64::hdf5-1.12.1-nompi_h2386368_104
  icu                conda-forge/linux-64::icu-70.1-h27087fc_0
  imagesize          conda-forge/noarch::imagesize-1.3.0-pyhd8ed1ab_0
  importlib-metadata conda-forge/linux-64::importlib-metadata-4.11.3-py37h89c1867_1
  importlib_metadata conda-forge/noarch::importlib_metadata-4.11.3-hd8ed1ab_1
  importlib_resourc~ conda-forge/noarch::importlib_resources-5.7.1-pyhd8ed1ab_1
  indexed_gzip       conda-forge/linux-64::indexed_gzip-1.6.13-py37h7dba1dc_0
  ipykernel          conda-forge/linux-64::ipykernel-6.13.0-py37h25bab4e_0
  ipython            conda-forge/linux-64::ipython-7.33.0-py37h89c1867_0
  ipython_genutils   conda-forge/noarch::ipython_genutils-0.2.0-py_1
  isodate            conda-forge/noarch::isodate-0.6.1-pyhd8ed1ab_0
  jbig               conda-forge/linux-64::jbig-2.1-h7f98852_2003
  jedi               conda-forge/linux-64::jedi-0.18.1-py37h89c1867_1
  jinja2             conda-forge/noarch::jinja2-3.1.2-pyhd8ed1ab_0
  jpeg               conda-forge/linux-64::jpeg-9e-h166bdaf_1
  jsonschema         conda-forge/noarch::jsonschema-4.5.1-pyhd8ed1ab_0
  jupyter_client     conda-forge/noarch::jupyter_client-7.3.1-pyhd8ed1ab_0
  jupyter_core       conda-forge/linux-64::jupyter_core-4.10.0-py37h89c1867_0
  jupyterlab_pygmen~ conda-forge/noarch::jupyterlab_pygments-0.2.2-pyhd8ed1ab_0
  keyutils           conda-forge/linux-64::keyutils-1.6.1-h166bdaf_0
  kiwisolver         conda-forge/linux-64::kiwisolver-1.4.2-py37h7cecad7_1
  krb5               conda-forge/linux-64::krb5-1.19.3-h3790be6_0
  lcms2              conda-forge/linux-64::lcms2-2.12-hddcbb42_0
  lerc               conda-forge/linux-64::lerc-3.0-h9c3ff4c_0
  libarchive         conda-forge/linux-64::libarchive-3.5.2-hb890918_2
  libblas            conda-forge/linux-64::libblas-3.9.0-14_linux64_openblas
  libbrotlicommon    conda-forge/linux-64::libbrotlicommon-1.0.9-h166bdaf_7
  libbrotlidec       conda-forge/linux-64::libbrotlidec-1.0.9-h166bdaf_7
  libbrotlienc       conda-forge/linux-64::libbrotlienc-1.0.9-h166bdaf_7
  libcblas           conda-forge/linux-64::libcblas-3.9.0-14_linux64_openblas
  libcurl            conda-forge/linux-64::libcurl-7.83.1-h7bff187_0
  libdeflate         conda-forge/linux-64::libdeflate-1.10-h7f98852_0
  libdrm             conda-forge/linux-64::libdrm-2.4.109-h7f98852_0
  libedit            conda-forge/linux-64::libedit-3.1.20191231-he28a2e2_2
  libev              conda-forge/linux-64::libev-4.33-h516909a_1
  libgfortran-ng     conda-forge/linux-64::libgfortran-ng-12.1.0-h69a702a_16
  libgfortran5       conda-forge/linux-64::libgfortran5-12.1.0-hdcd56e2_16
  libglib            conda-forge/linux-64::libglib-2.70.2-h174f98d_4
  libglu             conda-forge/linux-64::libglu-9.0.0-he1b5a44_1001
  libiconv           conda-forge/linux-64::libiconv-1.16-h516909a_0
  liblapack          conda-forge/linux-64::liblapack-3.9.0-14_linux64_openblas
  libmicrohttpd      conda-forge/linux-64::libmicrohttpd-0.9.75-h7f98852_0
  libnghttp2         conda-forge/linux-64::libnghttp2-1.47.0-h727a467_0
  libnsl             conda-forge/linux-64::libnsl-2.0.0-h7f98852_0
  libogg             conda-forge/linux-64::libogg-1.3.4-h7f98852_1
  libopenblas        conda-forge/linux-64::libopenblas-0.3.20-pthreads_h78a6416_0
  libopus            conda-forge/linux-64::libopus-1.3.1-h7f98852_1
  libpciaccess       conda-forge/linux-64::libpciaccess-0.16-h516909a_0
  libpng             conda-forge/linux-64::libpng-1.6.37-h21135ba_2
  libsodium          conda-forge/linux-64::libsodium-1.0.18-h36c2ea0_1
  libspatialindex    conda-forge/linux-64::libspatialindex-1.9.3-h9c3ff4c_4
  libssh2            conda-forge/linux-64::libssh2-1.10.0-ha56f1ee_2
  libtiff            conda-forge/linux-64::libtiff-4.3.0-h542a066_3
  libuuid            conda-forge/linux-64::libuuid-2.32.1-h7f98852_1000
  libvorbis          conda-forge/linux-64::libvorbis-1.3.7-h9c3ff4c_0
  libwebp            conda-forge/linux-64::libwebp-1.2.2-h3452ae3_0
  libwebp-base       conda-forge/linux-64::libwebp-base-1.2.2-h7f98852_1
  libxcb             conda-forge/linux-64::libxcb-1.13-h7f98852_1004
  libxml2            conda-forge/linux-64::libxml2-2.9.14-h22db469_0
  libzlib            conda-forge/linux-64::libzlib-1.2.11-h166bdaf_1014
  lz4-c              conda-forge/linux-64::lz4-c-1.9.3-h9c3ff4c_1
  lzo                conda-forge/linux-64::lzo-2.10-h516909a_1000
  markupsafe         conda-forge/linux-64::markupsafe-2.1.1-py37h540881e_1
  matplotlib-base    conda-forge/linux-64::matplotlib-base-3.5.2-py37hc347a89_0
  matplotlib-inline  conda-forge/noarch::matplotlib-inline-0.1.3-pyhd8ed1ab_0
  mesalib            conda-forge/linux-64::mesalib-21.2.5-h0e4506f_3
  mistune            conda-forge/linux-64::mistune-0.8.4-py37h5e8e339_1005
  munkres            conda-forge/noarch::munkres-1.1.4-pyh9f0ad1d_0
  nbclient           conda-forge/noarch::nbclient-0.6.3-pyhd8ed1ab_0
  nbconvert          conda-forge/noarch::nbconvert-6.5.0-pyhd8ed1ab_0
  nbconvert-core     conda-forge/noarch::nbconvert-core-6.5.0-pyhd8ed1ab_0
  nbconvert-pandoc   conda-forge/noarch::nbconvert-pandoc-6.5.0-pyhd8ed1ab_0
  nbformat           conda-forge/noarch::nbformat-5.4.0-pyhd8ed1ab_0
  nest-asyncio       conda-forge/noarch::nest-asyncio-1.5.5-pyhd8ed1ab_0
  nettle             conda-forge/linux-64::nettle-3.6-he412f7d_0
  nibabel            conda-forge/noarch::nibabel-3.2.2-pyhd8ed1ab_0
  notebook           conda-forge/noarch::notebook-6.4.11-pyha770c72_0
  numpy              conda-forge/linux-64::numpy-1.21.6-py37h976b520_0
  openjpeg           conda-forge/linux-64::openjpeg-2.4.0-hb52868f_1
  packaging          conda-forge/noarch::packaging-21.3-pyhd8ed1ab_0
  pandas             conda-forge/linux-64::pandas-1.3.5-py37he8f5f7f_0
  pandoc             conda-forge/linux-64::pandoc-2.18-ha770c72_0
  pandocfilters      conda-forge/noarch::pandocfilters-1.5.0-pyhd8ed1ab_0
  pango              conda-forge/linux-64::pango-1.50.7-hbd2fdc8_0
  parse              conda-forge/noarch::parse-1.19.0-pyh44b312d_0
  parso              conda-forge/noarch::parso-0.8.3-pyhd8ed1ab_0
  pathlib2           conda-forge/linux-64::pathlib2-2.3.7.post1-py37h89c1867_1
  pcre               conda-forge/linux-64::pcre-8.45-h9c3ff4c_0
  pexpect            conda-forge/noarch::pexpect-4.8.0-pyh9f0ad1d_2
  pickleshare        conda-forge/noarch::pickleshare-0.7.5-py_1003
  pillow             conda-forge/linux-64::pillow-9.1.1-py37h44f0d7a_0
  pixman             conda-forge/linux-64::pixman-0.40.0-h36c2ea0_0
  progressbar2       conda-forge/noarch::progressbar2-4.0.0-pyhd8ed1ab_0
  prometheus_client  conda-forge/noarch::prometheus_client-0.14.1-pyhd8ed1ab_0
  prompt-toolkit     conda-forge/noarch::prompt-toolkit-3.0.29-pyha770c72_0
  psutil             conda-forge/linux-64::psutil-5.9.0-py37h540881e_1
  pthread-stubs      conda-forge/linux-64::pthread-stubs-0.4-h36c2ea0_1001
  ptyprocess         conda-forge/noarch::ptyprocess-0.7.0-pyhd3deb0d_0
  pydicom            conda-forge/noarch::pydicom-2.3.0-pyh6c4a22f_0
  pygments           conda-forge/noarch::pygments-2.12.0-pyhd8ed1ab_0
  pyopengl           conda-forge/noarch::pyopengl-3.1.6-pyhd8ed1ab_1
  pyparsing          conda-forge/noarch::pyparsing-2.4.7-pyhd8ed1ab_1
  pypubsub           conda-forge/noarch::pypubsub-4.0.3-py_0
  pyrsistent         conda-forge/linux-64::pyrsistent-0.18.1-py37h540881e_1
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.2-pyhd8ed1ab_0
  python-fastjsonsc~ conda-forge/noarch::python-fastjsonschema-2.15.3-pyhd8ed1ab_0
  python-utils       conda-forge/noarch::python-utils-3.2.2-pyhd8ed1ab_0
  python_abi         conda-forge/linux-64::python_abi-3.7-2_cp37m
  pytz               conda-forge/noarch::pytz-2022.1-pyhd8ed1ab_0
  pyzmq              conda-forge/linux-64::pyzmq-23.0.0-py37h0c0c2a8_0
  rich               conda-forge/noarch::rich-12.4.1-pyhd8ed1ab_0
  rtree              conda-forge/linux-64::rtree-1.0.0-py37h0b55af0_1
  scipy              conda-forge/linux-64::scipy-1.7.3-py37hf2a6cf1_0
  send2trash         conda-forge/noarch::send2trash-1.8.0-pyhd8ed1ab_0
  snowballstemmer    conda-forge/noarch::snowballstemmer-2.2.0-pyhd8ed1ab_0
  soupsieve          conda-forge/noarch::soupsieve-2.3.1-pyhd8ed1ab_0
  sphinx             conda-forge/noarch::sphinx-4.5.0-pyh6c4a22f_0
  sphinx_rtd_theme   conda-forge/noarch::sphinx_rtd_theme-1.0.0-pyhd8ed1ab_0
  sphinxcontrib-app~ conda-forge/noarch::sphinxcontrib-applehelp-1.0.2-py_0
  sphinxcontrib-dev~ conda-forge/noarch::sphinxcontrib-devhelp-1.0.2-py_0
  sphinxcontrib-htm~ conda-forge/noarch::sphinxcontrib-htmlhelp-2.0.0-pyhd8ed1ab_0
  sphinxcontrib-jsm~ conda-forge/noarch::sphinxcontrib-jsmath-1.0.1-py_0
  sphinxcontrib-qth~ conda-forge/noarch::sphinxcontrib-qthelp-1.0.3-py_0
  sphinxcontrib-ser~ conda-forge/noarch::sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2
  terminado          conda-forge/linux-64::terminado-0.15.0-py37h89c1867_0
  textual            conda-forge/noarch::textual-0.1.18-pyhd8ed1ab_0
  tinycss2           conda-forge/noarch::tinycss2-1.1.1-pyhd8ed1ab_0
  tornado            conda-forge/linux-64::tornado-6.1-py37h540881e_3
  traitlets          conda-forge/noarch::traitlets-5.2.1.post0-pyhd8ed1ab_0
  trimesh            conda-forge/noarch::trimesh-3.12.0-pyh6c4a22f_0
  typing-extensions  conda-forge/noarch::typing-extensions-3.10.0.2-hd8ed1ab_0
  typing_extensions  conda-forge/noarch::typing_extensions-3.10.0.2-pyha770c72_0
  unicodedata2       conda-forge/linux-64::unicodedata2-14.0.0-py37h540881e_1
  wcwidth            conda-forge/noarch::wcwidth-0.2.5-pyh9f0ad1d_2
  webencodings       conda-forge/noarch::webencodings-0.5.1-py_1
  wxnatpy            conda-forge/noarch::wxnatpy-0.4.0-pyhd8ed1ab_0
  wxpython           conda-forge/linux-64::wxpython-4.1.1-py37hecb6014_7
  xarray             conda-forge/noarch::xarray-0.20.2-pyhd8ed1ab_0
  xnat               conda-forge/noarch::xnat-0.4.2-pyhd8ed1ab_0
  xorg-damageproto   conda-forge/linux-64::xorg-damageproto-1.2.1-h7f98852_1002
  xorg-fixesproto    conda-forge/linux-64::xorg-fixesproto-5.0-h7f98852_1002
  xorg-glproto       conda-forge/linux-64::xorg-glproto-1.4.17-h7f98852_1002
  xorg-kbproto       conda-forge/linux-64::xorg-kbproto-1.0.7-h7f98852_1002
  xorg-libice        conda-forge/linux-64::xorg-libice-1.0.10-h7f98852_0
  xorg-libsm         conda-forge/linux-64::xorg-libsm-1.2.3-hd9c2040_1000
  xorg-libx11        conda-forge/linux-64::xorg-libx11-1.7.2-h7f98852_0
  xorg-libxau        conda-forge/linux-64::xorg-libxau-1.0.9-h7f98852_0
  xorg-libxdamage    conda-forge/linux-64::xorg-libxdamage-1.1.5-h7f98852_1
  xorg-libxdmcp      conda-forge/linux-64::xorg-libxdmcp-1.1.3-h7f98852_0
  xorg-libxext       conda-forge/linux-64::xorg-libxext-1.3.4-h7f98852_1
  xorg-libxfixes     conda-forge/linux-64::xorg-libxfixes-5.0.3-h7f98852_1004
  xorg-libxrandr     conda-forge/linux-64::xorg-libxrandr-1.5.2-h7f98852_1
  xorg-libxrender    conda-forge/linux-64::xorg-libxrender-0.9.10-h7f98852_1003
  xorg-randrproto    conda-forge/linux-64::xorg-randrproto-1.5.0-h7f98852_1001
  xorg-renderproto   conda-forge/linux-64::xorg-renderproto-0.11.1-h7f98852_1002
  xorg-util-macros   conda-forge/linux-64::xorg-util-macros-1.19.3-h7f98852_0
  xorg-xextproto     conda-forge/linux-64::xorg-xextproto-7.3.0-h7f98852_1002
  xorg-xf86vidmodep~ conda-forge/linux-64::xorg-xf86vidmodeproto-2.3.1-h7f98852_1002
  xorg-xproto        conda-forge/linux-64::xorg-xproto-7.0.31-h7f98852_1007
  zeromq             conda-forge/linux-64::zeromq-4.3.4-h9c3ff4c_1
  zipp               conda-forge/noarch::zipp-3.8.0-pyhd8ed1ab_0
  zstd               conda-forge/linux-64::zstd-1.5.2-h8a70e8d_1

The following packages will be UPDATED:

  brotlipy           pkgs/main::brotlipy-0.7.0-py37h27cfd2~ --> conda-forge::brotlipy-0.7.0-py37h540881e_1004
  ca-certificates    pkgs/main::ca-certificates-2021.10.26~ --> conda-forge::ca-certificates-2022.5.18-ha878542_0
  certifi            pkgs/main::certifi-2021.10.8-py37h06a~ --> conda-forge::certifi-2022.5.18-py37h89c1867_0
  charset-normalizer pkgs/main::charset-normalizer-2.0.4-p~ --> conda-forge::charset-normalizer-2.0.12-pyhd8ed1ab_0
  conda              pkgs/main::conda-4.11.0-py37h06a4308_0 --> conda-forge::conda-4.12.0-py37h89c1867_0
  conda-content-tru~ pkgs/main::conda-content-trust-0.1.1-~ --> conda-forge::conda-content-trust-0.1.3-pyhd8ed1ab_0
  conda-package-han~ pkgs/main::conda-package-handling-1.7~ --> conda-forge::conda-package-handling-1.8.1-py37h540881e_1
  cryptography       pkgs/main::cryptography-36.0.0-py37h9~ --> conda-forge::cryptography-36.0.2-py37h38fbfac_1
  ld_impl_linux-64   pkgs/main::ld_impl_linux-64-2.35.1-h7~ --> conda-forge::ld_impl_linux-64-2.36.1-hea4e1c9_2
  libffi                   pkgs/main::libffi-3.3-he6710b0_2 --> conda-forge::libffi-3.4.2-h7f98852_5
  libgcc-ng          pkgs/main::libgcc-ng-9.3.0-h5101ec6_17 --> conda-forge::libgcc-ng-12.1.0-h8d9b700_16
  libgomp              pkgs/main::libgomp-9.3.0-h5101ec6_17 --> conda-forge::libgomp-12.1.0-h8d9b700_16
  libstdcxx-ng       pkgs/main::libstdcxx-ng-9.3.0-hd4cf53~ --> conda-forge::libstdcxx-ng-12.1.0-ha89aaad_16
  openssl              pkgs/main::openssl-1.1.1m-h7f8727e_0 --> conda-forge::openssl-1.1.1o-h166bdaf_0
  pip                pkgs/main/linux-64::pip-21.2.2-py37h0~ --> conda-forge/noarch::pip-22.1-pyhd8ed1ab_0
  pycosat            pkgs/main::pycosat-0.6.3-py37h27cfd23~ --> conda-forge::pycosat-0.6.3-py37h540881e_1010
  pyopenssl          pkgs/main::pyopenssl-21.0.0-pyhd3eb1b~ --> conda-forge::pyopenssl-22.0.0-pyhd8ed1ab_0
  pysocks                   pkgs/main::pysocks-1.7.1-py37_1 --> conda-forge::pysocks-1.7.1-py37h89c1867_5
  python                pkgs/main::python-3.7.11-h12debd9_0 --> conda-forge::python-3.7.12-hb7a2778_100_cpython
  setuptools         pkgs/main::setuptools-58.0.4-py37h06a~ --> conda-forge::setuptools-59.8.0-py37h89c1867_1
  sqlite                pkgs/main::sqlite-3.37.0-hc218d9a_0 --> conda-forge::sqlite-3.38.5-h4ff8645_0
  tk                        pkgs/main::tk-8.6.11-h1ccaba5_0 --> conda-forge::tk-8.6.12-h27826a3_0
  tqdm                  pkgs/main::tqdm-4.62.3-pyhd3eb1b0_1 --> conda-forge::tqdm-4.64.0-pyhd8ed1ab_0
  urllib3            pkgs/main::urllib3-1.26.7-pyhd3eb1b0_0 --> conda-forge::urllib3-1.26.9-pyhd8ed1ab_0
  xz                         pkgs/main::xz-5.2.5-h7b6447c_0 --> conda-forge::xz-5.2.5-h516909a_1
  yaml                     pkgs/main::yaml-0.2.5-h7b6447c_0 --> conda-forge::yaml-0.2.5-h7f98852_2
  zlib                    pkgs/main::zlib-1.2.11-h7f8727e_4 --> conda-forge::zlib-1.2.11-h166bdaf_1014

The following packages will be SUPERSEDED by a higher-priority channel:

  _libgcc_mutex           pkgs/main::_libgcc_mutex-0.1-main --> conda-forge::_libgcc_mutex-0.1-conda_forge
  _openmp_mutex          pkgs/main::_openmp_mutex-4.5-1_gnu --> conda-forge::_openmp_mutex-4.5-2_gnu
  cffi                pkgs/main::cffi-1.15.0-py37hd667e15_1 --> conda-forge::cffi-1.15.0-py37h036bc23_0
  idna                     pkgs/main::idna-3.3-pyhd3eb1b0_0 --> conda-forge::idna-3.3-pyhd8ed1ab_0
  ncurses                 pkgs/main::ncurses-6.3-h7f8727e_2 --> conda-forge::ncurses-6.3-h27087fc_1
  pycparser          pkgs/main::pycparser-2.21-pyhd3eb1b0_0 --> conda-forge::pycparser-2.21-pyhd8ed1ab_0
  readline             pkgs/main::readline-8.1.2-h7f8727e_1 --> conda-forge::readline-8.1-h46c0cb4_0
  requests           pkgs/main::requests-2.27.1-pyhd3eb1b0~ --> conda-forge::requests-2.27.1-pyhd8ed1ab_0
  ruamel_yaml        pkgs/main::ruamel_yaml-0.15.100-py37h~ --> conda-forge::ruamel_yaml-0.15.80-py37h5e8e339_1006
  six                    pkgs/main::six-1.16.0-pyhd3eb1b0_0 --> conda-forge::six-1.16.0-pyh6c4a22f_0
  wheel                pkgs/main::wheel-0.37.1-pyhd3eb1b0_0 --> conda-forge::wheel-0.37.1-pyhd8ed1ab_0
```

</details>

On a hunch that the problem was largely due to

> The following packages will be SUPERSEDED by a higher-priority channel:

e.g.

>   ncurses                 pkgs/main::ncurses-6.3-h7f8727e_2 --> conda-forge::ncurses-6.3-h27087fc_1

where it has to replace the Anaconda package with the conda-forge package, this PR is here to switch to using conda-forge from the start and side-step ever using Anaconda.


## Linked Issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

See https://github.com/shimming-toolbox/shimming-toolbox/issues/369#issuecomment-1118688540
