### PR TITLE
Bump version and implement features

### DIFF
--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION="6a8893570d38ae571c4977d76f063ba5a4815a7d"
+ST_VERSION="73b9410f0b26845f65a2a6425e84f2d4e55f4599"
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION="73b9410f0b26845f65a2a6425e84f2d4e55f4599"
+ST_VERSION="f577494bd9efb119763447db4300e1cc96dfc0d2"
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 


### PR DESCRIPTION
## Description
This PR brings the plugin up to date with relevant features in shimming toolbox. It also adds the ability to have more than 1 component linked to a dropdown.

More precisely, this PR adds:
- Support for changing optimizers (MAE, MSE)
- Displays `--output-file-format-scanner` and `--scanner-coil-constraints` only when `--scanner-coil-order` is not '-1'.
- Displays `--regularization-factor` and `--optimizer-criteria` when `--optimizer-method` is 'least_squares' and not for 'pseudo-inverse'
- Support for multi echo field mapping 
