### PR TITLE
Solve bug preventing to launch Shimming Toolbox on linux

### DIFF
--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -1843,7 +1843,15 @@ class MaskTab(Tab):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        selection = self.choice_box.GetString(self.choice_box.GetSelection())
+        print(self.choice_box.GetSelection())
+        if self.choice_box.GetSelection() < 0:
+            print("\nNo selection was found, setting it to the first value")
+            selection = self.choice_box.GetString(0)
+            self.choice_box.SetSelection(0)
+        else:
+            selection = self.choice_box.GetString(self.choice_box.GetSelection())
+
+        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()

--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -384,11 +384,12 @@ class DropdownComponent(Component):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        if not isinstance(self.choice_box.GetSelection(), int):
+        print(self.choice_box.GetSelection())
+        if self.choice_box.GetSelection() < 0:
             print("\nNo selection was found, setting it to the first value")
             selection = self.choice_box.GetString(0)
+            # self.choice_box.SetSelection(0)
         else:
-            print(f"\n{self.choice_box.GetSelection()}")
             selection = self.choice_box.GetString(self.choice_box.GetSelection())
 
         print(f"\n{selection}")

--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -384,15 +384,11 @@ class DropdownComponent(Component):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        print(self.choice_box.GetSelection())
         if self.choice_box.GetSelection() < 0:
-            print("\nNo selection was found, setting it to the first value")
             selection = self.choice_box.GetString(0)
             self.choice_box.SetSelection(0)
         else:
             selection = self.choice_box.GetString(self.choice_box.GetSelection())
-
-        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()
@@ -721,15 +717,11 @@ class B0ShimTab(Tab):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        print(self.choice_box.GetSelection())
         if self.choice_box.GetSelection() < 0:
-            print("\nNo selection was found, setting it to the first value")
             selection = self.choice_box.GetString(0)
             self.choice_box.SetSelection(0)
         else:
             selection = self.choice_box.GetString(self.choice_box.GetSelection())
-
-        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()
@@ -1481,15 +1473,11 @@ class B1ShimTab(Tab):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        print(self.choice_box.GetSelection())
         if self.choice_box.GetSelection() < 0:
-            print("\nNo selection was found, setting it to the first value")
             selection = self.choice_box.GetString(0)
             self.choice_box.SetSelection(0)
         else:
             selection = self.choice_box.GetString(self.choice_box.GetSelection())
-
-        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()
@@ -1859,15 +1847,11 @@ class MaskTab(Tab):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        print(self.choice_box.GetSelection())
         if self.choice_box.GetSelection() < 0:
-            print("\nNo selection was found, setting it to the first value")
             selection = self.choice_box.GetString(0)
             self.choice_box.SetSelection(0)
         else:
             selection = self.choice_box.GetString(self.choice_box.GetSelection())
-
-        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()

--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -388,7 +388,7 @@ class DropdownComponent(Component):
         if self.choice_box.GetSelection() < 0:
             print("\nNo selection was found, setting it to the first value")
             selection = self.choice_box.GetString(0)
-            # self.choice_box.SetSelection(0)
+            self.choice_box.SetSelection(0)
         else:
             selection = self.choice_box.GetString(self.choice_box.GetSelection())
 

--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -384,7 +384,14 @@ class DropdownComponent(Component):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        selection = self.choice_box.GetString(self.choice_box.GetSelection())
+        if not isinstance(self.choice_box.GetSelection(), int):
+            print("\nNo selection was found, setting it to the first value")
+            selection = self.choice_box.GetString(0)
+        else:
+            print(f"\n{self.choice_box.GetSelection()}")
+            selection = self.choice_box.GetString(self.choice_box.GetSelection())
+
+        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()

--- a/fsleyes_plugin_shimming_toolbox/st_plugin.py
+++ b/fsleyes_plugin_shimming_toolbox/st_plugin.py
@@ -721,7 +721,15 @@ class B0ShimTab(Tab):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        selection = self.choice_box.GetString(self.choice_box.GetSelection())
+        print(self.choice_box.GetSelection())
+        if self.choice_box.GetSelection() < 0:
+            print("\nNo selection was found, setting it to the first value")
+            selection = self.choice_box.GetString(0)
+            self.choice_box.SetSelection(0)
+        else:
+            selection = self.choice_box.GetString(self.choice_box.GetSelection())
+
+        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()
@@ -1473,7 +1481,15 @@ class B1ShimTab(Tab):
 
     def on_choice(self, event):
         # Get the selection from the choice box widget
-        selection = self.choice_box.GetString(self.choice_box.GetSelection())
+        print(self.choice_box.GetSelection())
+        if self.choice_box.GetSelection() < 0:
+            print("\nNo selection was found, setting it to the first value")
+            selection = self.choice_box.GetString(0)
+            self.choice_box.SetSelection(0)
+        else:
+            selection = self.choice_box.GetString(self.choice_box.GetSelection())
+
+        print(f"\n{selection}")
 
         # Unshow everything then show the correct item according to the choice box
         self.unshow_choice_box_sizers()


### PR DESCRIPTION
## Description
Shimming Toolbox crashes on startup because the choice boxes selection are not initialized on linux (their selection is set to -1 instead). This PR adds a simple fix that selects the first option (0), if the selection is negative.

I have tested it on Ubuntu 22.04.

Note: I think this bug was introduced when we upgraded wxPython. On wxPython 4.0.7, launching ST would not crash but required the user to select from the options from the dropdown lists to show the different tabs. With the above fix, we now get a similar result to what we get on macOS.

## Linked Issues
https://github.com/shimming-toolbox/shimming-toolbox/issues/433
