### PR TITLE
Adapt GUI to new split optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 .idea
 dcm2bids.json
 output_*
+./vscode
 
 # Project's data
 testing_data

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "python.testing.pytestArgs": [
-        "test"
+        "."
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.testing.cwd": "./test"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "."
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.testing.cwd": "./test"
-}

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -2,34 +2,74 @@ import wx
 from fsleyes_plugin_shimming_toolbox.components.component import Component
 from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
 
-class CheckboxComponent():
-    def __init__(self, panel, label, info_text=None):
-        # super().__init__(panel, label=label)
+class CheckboxComponent(Component):
+    def __init__(self, panel, label, checkbox_metadata, option_name, components_dict={}, info_text=None):
+        """
+        Args:
+            list_components (list): list of Components
+            component_to_dropdown_choice (list): Tells which component associates with which dropdown selection.
+                                                 If None, assumes 1:1.
+        """
         self.sizer = self.create_sizer()
+
+        self.checkbox_metadata = checkbox_metadata
+        self.option_name = option_name
+
         self.panel = panel
         self.label = label
         self.info_text = info_text
+        self.children = components_dict
+
+        self.create_display()
+        
+    def create_display(self):
         # Button
         self.info_icon = create_info_icon(self.panel, self.info_text)
         self.button = wx.Button(self.panel, -1, label=self.label)
         
         # Checkboxes
-        self.checkbox_f0 = wx.CheckBox(self.panel, label="f0")
-        self.checkbox_1 = wx.CheckBox(self.panel, label="1")
-        self.checkbox_2 = wx.CheckBox(self.panel, label="2")
+        self.checkboxes = []
+        for metadata in self.checkbox_metadata:
+            self.checkboxes.append(wx.CheckBox(self.panel, label=metadata["label"]))
         
         # Add checkboxes to sizer
         self.checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.checkbox_sizer.Add(self.info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
         self.checkbox_sizer.Add(self.button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
-        self.checkbox_sizer.Add(self.checkbox_f0, 0, wx.ALL, 5)
-        self.checkbox_sizer.Add(self.checkbox_1, 0, wx.ALL, 5)
-        self.checkbox_sizer.Add(self.checkbox_2, 0, wx.ALL, 5)
+        for checkbox in self.checkboxes:
+            # Bind
+            checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
+            self.checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)        # Add to sizer + spacer below
         
-        # Add to sizer + spacer below
         self.sizer.Add(self.checkbox_sizer)
         self.sizer.AddSpacer(10)
         
+        # Add children
+        self.add_children()
+        
+        wx.CallAfter(self.show_children_sizers, None)
+
+    def add_children(self):
+        for child in self.children:
+            self.sizer.Add(child['object'].sizer, 0, wx.EXPAND)
+
+    def show_children_sizers(self, event):
+        childrens_to_show = self.get_children_to_show()
+        for child in self.children:
+            if child['object'] in childrens_to_show:
+                child['object'].sizer.ShowItems(True)
+            else:
+                child['object'].sizer.ShowItems(False)
+        self.panel.SetVirtualSize(self.panel.sizer_run.GetMinSize())
+        self.panel.Layout()
+
+    def get_children_to_show(self):
+        """Get the children to show based on the checkbox selection"""
+        checked_indices = {checkbox.GetLabel() for checkbox in self.checkboxes if checkbox.GetValue()}
+        children_to_show = [child['object'] for child in self.children if set(child['checkbox']).intersection(checked_indices)]
+        
+        return children_to_show
+     
     def create_sizer(self):
         """Create the centre sizer containing tab-specific functionality."""
         sizer = wx.BoxSizer(wx.VERTICAL)

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -99,7 +99,7 @@ class CheckboxComponent(Component):
             if type(child) == InputComponent:
                 cmd, output, overlay = child.get_command()
             else:
-                cmd = child.get_command()
+                cmd, _, _ = child.get_command()
                 
             command.extend(cmd)
         

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -3,6 +3,7 @@ from fsleyes_plugin_shimming_toolbox.components.component import Component
 from fsleyes_plugin_shimming_toolbox.components.input_component import InputComponent
 from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
 
+
 class CheckboxComponent(Component):
     def __init__(self, panel, label, checkbox_metadata, option_name, components_dict={}, info_text=None):
         """
@@ -22,17 +23,17 @@ class CheckboxComponent(Component):
         self.children = components_dict
 
         self.create_display()
-        
+
     def create_display(self):
         # Button
         self.info_icon = create_info_icon(self.panel, self.info_text)
         self.button = wx.Button(self.panel, -1, label=self.label)
-        
+
         # Checkboxes
         self.checkboxes = []
         for metadata in self.checkbox_metadata:
             self.checkboxes.append(wx.CheckBox(self.panel, label=metadata["label"]))
-        
+
         # Add checkboxes to sizer
         self.checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.checkbox_sizer.Add(self.info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
@@ -41,13 +42,13 @@ class CheckboxComponent(Component):
             # Bind
             checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
             self.checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)        # Add to sizer + spacer below
-        
+
         self.sizer.Add(self.checkbox_sizer)
         self.sizer.AddSpacer(10)
-        
+
         # Add children
         self.add_children()
-        
+
         wx.CallAfter(self.show_children_sizers, None)
 
     def add_children(self):
@@ -68,14 +69,14 @@ class CheckboxComponent(Component):
         """Get the children to show based on the checkbox selection"""
         checked_indices = {checkbox.GetLabel() for checkbox in self.checkboxes if checkbox.GetValue()}
         children_to_show = [child['object'] for child in self.children if set(child['checkbox']).intersection(checked_indices)]
-        
+
         return children_to_show
-     
+
     def create_sizer(self):
         """Create the centre sizer containing tab-specific functionality."""
         sizer = wx.BoxSizer(wx.VERTICAL)
         return sizer
-    
+
     def get_command(self):
         command = []
         output = None
@@ -88,19 +89,19 @@ class CheckboxComponent(Component):
                     args += '0,'
                 else:
                     args += str(checkbox.GetLabel()) + ','
-                
+
         if self.option_name == "arg":
             command.append(args[:-1])
         else:
             command.extend(['--' + self.option_name, args[:-1]])
-        
+
         children_to_return = self.get_children_to_show()
         for child in children_to_return:
             if type(child) == InputComponent:
                 cmd, output, overlay = child.get_command()
             else:
                 cmd, _, _ = child.get_command()
-                
+
             command.extend(cmd)
-        
+
         return command, output, overlay

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -16,7 +16,9 @@ class CheckboxComponent(Component):
 
         self.checkbox_metadata = checkbox_metadata
         self.option_name = option_name
-
+        self.checkboxes = []
+        self.checkboxes_riro = []
+        
         self.panel = panel
         self.label = label
         self.info_text = info_text
@@ -30,48 +32,40 @@ class CheckboxComponent(Component):
         self.info_icon = create_info_icon(self.panel, self.info_text)
         self.button = wx.Button(self.panel, -1, label=self.label)
 
-        # Checkboxes
-        self.checkboxes = []
-        for metadata in self.checkbox_metadata:
-            self.checkboxes.append(wx.CheckBox(self.panel, label=metadata["label"]))
-
-        # Add checkboxes to sizer
-        self.checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.checkbox_sizer.Add(self.info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
-        self.checkbox_sizer.Add(self.button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
-        for checkbox in self.checkboxes:
-            # Bind
-            checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
-            self.checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)        # Add to sizer + spacer below
-
-        self.sizer.Add(self.checkbox_sizer)
-        self.sizer.AddSpacer(10)
+        self.add_checkbox_sizer(self.checkbox_metadata, self.info_icon, self.button)
         
         if self.additional_sizer_dict is not None:
             info_icon = create_info_icon(self.panel, self.additional_sizer_dict["info text"])
             button = wx.Button(self.panel, -1, label=self.additional_sizer_dict["label"])
-            
-            additional_checkboxes = []
-            for metadata in self.additional_sizer_dict["checkbox metadata"]:
-                additional_checkboxes.append(wx.CheckBox(self.panel, label=metadata["label"]))
-            
-            # Add checkboxes to sizer
-            additional_checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
-            additional_checkbox_sizer.Add(info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
-            additional_checkbox_sizer.Add(button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
-            for checkbox in additional_checkboxes:
-                # Bind
-                checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
-                additional_checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)
-            self.checkboxes.extend(additional_checkboxes)
-            self.sizer.Add(additional_checkbox_sizer)
-            self.sizer.AddSpacer(10)
+            self.add_checkbox_sizer(self.additional_sizer_dict["checkbox metadata"], 
+                                    info_icon, button, riro=True)
 
         # Add children
         self.add_children()
 
         wx.CallAfter(self.show_children_sizers, None)
 
+    def add_checkbox_sizer(self, checkbox_metadata, info_icon, button, riro=False):
+        temp_checkboxes = []
+        # Checkboxes
+        for metadata in checkbox_metadata:
+            temp_checkboxes.append(wx.CheckBox(self.panel, label=metadata["label"]))
+
+        # Add checkboxes to sizer
+        checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        checkbox_sizer.Add(info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
+        checkbox_sizer.Add(button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
+        for checkbox in temp_checkboxes:
+            # Bind
+            checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
+            checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)        # Add to sizer + spacer below
+        if riro:
+            self.checkboxes_riro.extend(temp_checkboxes)
+        else:
+            self.checkboxes.extend(temp_checkboxes)
+        self.sizer.Add(checkbox_sizer)
+        self.sizer.AddSpacer(10)
+    
     def add_children(self):
         for child in self.children:
             self.sizer.Add(child['object'].sizer, 0, wx.EXPAND)
@@ -88,7 +82,7 @@ class CheckboxComponent(Component):
 
     def get_children_to_show(self):
         """Get the children to show based on the checkbox selection"""
-        checked_indices = {checkbox.GetLabel() for checkbox in self.checkboxes if checkbox.GetValue()}
+        checked_indices = {checkbox.GetLabel() for checkbox in self.checkboxes + self.checkboxes_riro if checkbox.GetValue()}
         children_to_show = [child['object'] for child in self.children if set(child['checkbox']).intersection(checked_indices)]
 
         return children_to_show

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -92,24 +92,33 @@ class CheckboxComponent(Component):
         sizer = wx.BoxSizer(wx.VERTICAL)
         return sizer
 
-    def get_command(self):
-        command = []
-        output = None
-        overlay = []
+    def get_argument(self, checkboxes):
         args = ""
-        for checkbox in self.checkboxes:
+        for checkbox in checkboxes:
             if checkbox.GetValue():
                 label = checkbox.GetLabel()
                 if label == 'f0':
                     args += '0,'
                 else:
                     args += str(checkbox.GetLabel()) + ','
+        return args[:-1]
+    
+    def get_command(self):
+        command = []
+        output = None
+        overlay = []
+        
+        args = self.get_argument(self.checkboxes)
 
         if self.option_name == "arg":
-            command.append(args[:-1])
+            command.append(args)
         else:
-            command.extend(['--' + self.option_name, args[:-1]])
+            command.extend(['--' + self.option_name, args])
 
+        if self.checkboxes_riro:
+            args_riro = self.get_argument(self.checkboxes_riro)
+            command.extend(['--' + self.additional_sizer_dict["option name"], args_riro])
+            
         children_to_return = self.get_children_to_show()
         for child in children_to_return:
             if type(child) == InputComponent:

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -7,10 +7,22 @@ from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
 class CheckboxComponent(Component):
     def __init__(self, panel, label, checkbox_metadata, option_name, components_dict={}, info_text=None, additional_sizer_dict=None):
         """
+        Create a checkbox object
         Args:
-            list_components (list): list of Components
-            component_to_dropdown_choice (list): Tells which component associates with which dropdown selection.
-                                                 If None, assumes 1:1.
+            panel (wx.Panel): A panel is a window on which controls are placed.
+            label (str): Label of the button describing the checkbox
+            checkbox_metadata (list)(dict): A list of dictionaries where the dictionaries have the
+                required keys: ``label``, ``option_value``.
+                .. code::
+                    
+                        {
+                            "label": The label for the checkbox
+                            "option_value": The value linked to the option in the CLI
+                        }
+            option_name (str): Name of the options of the checkbox, start with 'no_arg' if it is not an option
+            components_dict (dict): Dictionary of components to shown when the checkbox is checked
+            info_text (str): Info message displayed when hovering over the "i" icon. Leave blank to auto fill using option_name
+            additional_sizer_dict (dict): Dictionary of additional checkbox to be added to the sizer
         """
         self.sizer = self.create_sizer()
 
@@ -43,7 +55,7 @@ class CheckboxComponent(Component):
         # Add children
         self.add_children()
 
-        wx.CallAfter(self.show_children_sizers, None)
+        wx.CallAfter(self.on_choice, None)
 
     def add_checkbox_sizer(self, checkbox_metadata, info_icon, button, riro=False):
         temp_checkboxes = []
@@ -57,7 +69,7 @@ class CheckboxComponent(Component):
         checkbox_sizer.Add(button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
         for checkbox in temp_checkboxes:
             # Bind
-            checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
+            checkbox.Bind(wx.EVT_CHECKBOX, self.on_choice)
             checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)        # Add to sizer + spacer below
         if riro:
             self.checkboxes_riro.extend(temp_checkboxes)
@@ -70,7 +82,7 @@ class CheckboxComponent(Component):
         for child in self.children:
             self.sizer.Add(child['object'].sizer, 0, wx.EXPAND)
 
-    def show_children_sizers(self, event):
+    def on_choice(self, event):
         childrens_to_show = self.get_children_to_show()
         for child in self.children:
             if child['object'] in childrens_to_show:
@@ -94,6 +106,7 @@ class CheckboxComponent(Component):
 
     def get_argument(self, checkboxes):
         args = ""
+        {item['label']: item['option_value'] for item in self.checkbox_metadata}
         for checkbox in checkboxes:
             if checkbox.GetValue():
                 label = checkbox.GetLabel()

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -1,0 +1,37 @@
+import wx
+from fsleyes_plugin_shimming_toolbox.components.component import Component
+from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
+
+class CheckboxComponent():
+    def __init__(self, panel, label, info_text=None):
+        # super().__init__(panel, label=label)
+        self.sizer = self.create_sizer()
+        self.panel = panel
+        self.label = label
+        self.info_text = info_text
+        # Button
+        self.info_icon = create_info_icon(self.panel, self.info_text)
+        self.button = wx.Button(self.panel, -1, label=self.label)
+        
+        # Checkboxes
+        self.checkbox_f0 = wx.CheckBox(self.panel, label="f0")
+        self.checkbox_1 = wx.CheckBox(self.panel, label="1")
+        self.checkbox_2 = wx.CheckBox(self.panel, label="2")
+        
+        # Add checkboxes to sizer
+        self.checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.checkbox_sizer.Add(self.info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
+        self.checkbox_sizer.Add(self.button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
+        self.checkbox_sizer.Add(self.checkbox_f0, 0, wx.ALL, 5)
+        self.checkbox_sizer.Add(self.checkbox_1, 0, wx.ALL, 5)
+        self.checkbox_sizer.Add(self.checkbox_2, 0, wx.ALL, 5)
+        
+        # Add to sizer + spacer below
+        self.sizer.Add(self.checkbox_sizer)
+        self.sizer.AddSpacer(10)
+        
+    def create_sizer(self):
+        """Create the centre sizer containing tab-specific functionality."""
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        return sizer
+    

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -5,7 +5,7 @@ from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
 
 
 class CheckboxComponent(Component):
-    def __init__(self, panel, label, checkbox_metadata, option_name, components_dict={}, info_text=None):
+    def __init__(self, panel, label, checkbox_metadata, option_name, components_dict={}, info_text=None, additional_sizer_dict=None):
         """
         Args:
             list_components (list): list of Components
@@ -21,7 +21,8 @@ class CheckboxComponent(Component):
         self.label = label
         self.info_text = info_text
         self.children = components_dict
-
+        self.additional_sizer_dict = additional_sizer_dict
+        
         self.create_display()
 
     def create_display(self):
@@ -45,6 +46,26 @@ class CheckboxComponent(Component):
 
         self.sizer.Add(self.checkbox_sizer)
         self.sizer.AddSpacer(10)
+        
+        if self.additional_sizer_dict is not None:
+            info_icon = create_info_icon(self.panel, self.additional_sizer_dict["info text"])
+            button = wx.Button(self.panel, -1, label=self.additional_sizer_dict["label"])
+            
+            additional_checkboxes = []
+            for metadata in self.additional_sizer_dict["checkbox metadata"]:
+                additional_checkboxes.append(wx.CheckBox(self.panel, label=metadata["label"]))
+            
+            # Add checkboxes to sizer
+            additional_checkbox_sizer = wx.BoxSizer(wx.HORIZONTAL)
+            additional_checkbox_sizer.Add(info_icon, 0, wx.ALIGN_LEFT | wx.RIGHT, 7)
+            additional_checkbox_sizer.Add(button, 0, wx.ALIGN_LEFT | wx.RIGHT, 10)
+            for checkbox in additional_checkboxes:
+                # Bind
+                checkbox.Bind(wx.EVT_CHECKBOX, self.show_children_sizers)
+                additional_checkbox_sizer.Add(checkbox, 0, wx.ALL, 5)
+            self.checkboxes.extend(additional_checkboxes)
+            self.sizer.Add(additional_checkbox_sizer)
+            self.sizer.AddSpacer(10)
 
         # Add children
         self.add_children()

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -1,5 +1,6 @@
 import wx
 from fsleyes_plugin_shimming_toolbox.components.component import Component
+from fsleyes_plugin_shimming_toolbox.components.input_component import InputComponent
 from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
 
 class CheckboxComponent(Component):
@@ -75,3 +76,31 @@ class CheckboxComponent(Component):
         sizer = wx.BoxSizer(wx.VERTICAL)
         return sizer
     
+    def get_command(self):
+        command = []
+        output = None
+        overlay = []
+        args = ""
+        for checkbox in self.checkboxes:
+            if checkbox.GetValue():
+                label = checkbox.GetLabel()
+                if label == 'f0':
+                    args += '0,'
+                else:
+                    args += str(checkbox.GetLabel()) + ','
+                
+        if self.option_name == "arg":
+            command.append(args[:-1])
+        else:
+            command.extend(['--' + self.option_name, args[:-1]])
+        
+        children_to_return = self.get_children_to_show()
+        for child in children_to_return:
+            if type(child) == InputComponent:
+                cmd, output, overlay = child.get_command()
+            else:
+                cmd = child.get_command()
+                
+            command.extend(cmd)
+        
+        return command, output, overlay

--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -106,14 +106,11 @@ class CheckboxComponent(Component):
 
     def get_argument(self, checkboxes):
         args = ""
-        {item['label']: item['option_value'] for item in self.checkbox_metadata}
+        option_values = {item['label']: item['option_value'] for item in self.checkbox_metadata}
         for checkbox in checkboxes:
             if checkbox.GetValue():
                 label = checkbox.GetLabel()
-                if label == 'f0':
-                    args += '0,'
-                else:
-                    args += str(checkbox.GetLabel()) + ','
+                args += option_values[label] + ','
         return args[:-1]
     
     def get_command(self):

--- a/fsleyes_plugin_shimming_toolbox/components/component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/component.py
@@ -17,6 +17,10 @@ class Component:
     @classmethod
     def __subclasshook__(cls, subclass):
         return hasattr(subclass, 'create_sizer') and callable(subclass.create_sizer) or NotImplemented
+    
+    @abc.abstractmethod
+    def get_command(self):
+        raise NotImplementedError
 
 
 def get_help_text(cli_function, name):
@@ -29,3 +33,8 @@ def get_help_text(cli_function, name):
                 return param.help
 
     raise ValueError(f"Could not find param: {name} in {cli_function.name}")
+
+
+class RunArgumentErrorST(Exception):
+    """Exception for missing input arguments for CLI call."""
+    pass

--- a/fsleyes_plugin_shimming_toolbox/components/component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/component.py
@@ -38,3 +38,4 @@ def get_help_text(cli_function, name):
 class RunArgumentErrorST(Exception):
     """Exception for missing input arguments for CLI call."""
     pass
+    

--- a/fsleyes_plugin_shimming_toolbox/components/dropdown_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/dropdown_component.py
@@ -193,7 +193,6 @@ class DropdownComponent(Component):
                     else:
                         input_text_boxes = {name: input_text_box_list}
                         
-                        # TODO: Fix
                         cmd, output, load_in_overlay = get_command_dict(input_text_boxes)
                         command.extend(cmd)
         return command, output, load_in_overlay

--- a/fsleyes_plugin_shimming_toolbox/components/dropdown_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/dropdown_component.py
@@ -4,6 +4,7 @@
 import wx
 
 from fsleyes_plugin_shimming_toolbox.components.component import Component, get_help_text
+from fsleyes_plugin_shimming_toolbox.components.input_component import get_command_dict
 from fsleyes_plugin_shimming_toolbox.text_with_button import create_info_icon
 
 
@@ -175,3 +176,24 @@ class DropdownComponent(Component):
         """Create a sizer containing tab-specific functionality."""
         sizer = wx.BoxSizer(wx.VERTICAL)
         return sizer
+    
+    def get_command(self):
+        """Return the selcted options in the dropdown"""
+        command = []
+        output = None
+        load_in_overlay = []
+        for name, input_text_box_list in self.input_text_boxes.items():
+                if name.startswith('no_arg'):
+                    continue
+
+                for input_text_box in input_text_box_list:
+                    # Allows to choose from a dropdown
+                    if type(input_text_box) == str:
+                        command.extend(['--'+ name, input_text_box])
+                    else:
+                        input_text_boxes = {name: input_text_box_list}
+                        
+                        # TODO: Fix
+                        cmd, output, load_in_overlay = get_command_dict(input_text_boxes)
+                        command.extend(cmd)
+        return command, output, load_in_overlay

--- a/fsleyes_plugin_shimming_toolbox/components/input_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/input_component.py
@@ -141,8 +141,8 @@ def get_command_dict(input_text_boxes):
                         print(option_values)
                         
                 # If its an argument don't include it as an option, if the option list is empty don't either
-                if not is_arg and option_values:
-                    command_list_options.append((name, option_values))
+            if not is_arg and option_values:
+                command_list_options.append((name, option_values))
 
     # Arguments don't need "-"
     for arg in command_list_arguments:

--- a/fsleyes_plugin_shimming_toolbox/components/input_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/input_component.py
@@ -155,3 +155,4 @@ def get_command_dict(input_text_boxes):
             command.append(arg)
 
     return command, output, load_in_overlay
+    

--- a/fsleyes_plugin_shimming_toolbox/components/input_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/input_component.py
@@ -3,7 +3,7 @@
 
 import wx
 
-from fsleyes_plugin_shimming_toolbox.components.component import Component, get_help_text
+from fsleyes_plugin_shimming_toolbox.components.component import Component, get_help_text, RunArgumentErrorST
 from fsleyes_plugin_shimming_toolbox.text_with_button import TextWithButton
 
 
@@ -91,3 +91,67 @@ class InputComponent(Component):
 
     def button_do_something(self, event):
         pass
+
+    def get_command(self):
+        """ Returns the arguments of the input text boxes.
+
+        Returns:
+            args (string): argmuents of the input text boxes
+        """
+
+        return get_command_dict(self.input_text_boxes)
+
+
+def get_command_dict(input_text_boxes):
+
+    command = []
+    command_list_arguments = []
+    command_list_options = []
+    output = ""
+    load_in_overlay = []
+    for name, input_text_box_list in input_text_boxes.items():
+
+        if name.startswith('no_arg'):
+            continue
+
+        for input_text_box in input_text_box_list:
+            print(input_text_box)
+            is_arg = False
+            option_values = []
+            for textctrl in input_text_box.textctrl_list:
+                arg = textctrl.GetValue()
+                if arg == "" or arg is None:
+                    if input_text_box.required is True:
+                        raise RunArgumentErrorST(
+                            f"Argument {name} is missing a value, please enter a valid input"
+                        )
+                else:
+                    # Case where the option name is set to arg, this handles it as if it were an argument
+                    if name == "arg":
+                        command_list_arguments.append(arg)
+                        is_arg = True
+                    # Normal options
+                    else:
+                        if name == "output":
+                            output = arg
+                        elif input_text_box.load_in_overlay:
+                            load_in_overlay.append(arg)
+                        
+                        option_values.append(arg)
+                        print(option_values)
+                        
+                # If its an argument don't include it as an option, if the option list is empty don't either
+                if not is_arg and option_values:
+                    command_list_options.append((name, option_values))
+
+    # Arguments don't need "-"
+    for arg in command_list_arguments:
+        command.append(arg)
+
+    # Handles options
+    for name, args in command_list_options:
+        command.append('--' + name)
+        for arg in args:
+            command.append(arg)
+
+    return command, output, load_in_overlay

--- a/fsleyes_plugin_shimming_toolbox/components/input_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/input_component.py
@@ -115,7 +115,6 @@ def get_command_dict(input_text_boxes):
             continue
 
         for input_text_box in input_text_box_list:
-            print(input_text_box)
             is_arg = False
             option_values = []
             for textctrl in input_text_box.textctrl_list:
@@ -138,7 +137,6 @@ def get_command_dict(input_text_boxes):
                             load_in_overlay.append(arg)
                         
                         option_values.append(arg)
-                        print(option_values)
                         
                 # If its an argument don't include it as an option, if the option list is empty don't either
             if not is_arg and option_values:

--- a/fsleyes_plugin_shimming_toolbox/components/run_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/run_component.py
@@ -10,7 +10,8 @@ import os
 import wx
 
 from fsleyes_plugin_shimming_toolbox import __DIR_ST_PLUGIN_IMG__
-from fsleyes_plugin_shimming_toolbox.components.component import Component
+from fsleyes_plugin_shimming_toolbox.components.component import Component, RunArgumentErrorST
+from fsleyes_plugin_shimming_toolbox.components.input_component import InputComponent
 from fsleyes_plugin_shimming_toolbox.events import EVT_RESULT, EVT_LOG
 from fsleyes_plugin_shimming_toolbox.worker_thread import WorkerThread
 
@@ -184,66 +185,17 @@ class RunComponent(Component):
         msg = "Running "
         # Split is necessary if we have grouped commands (st_mask threshold)
         command = st_function.split(' ')
-
-        self.output = ""
-        command_list_arguments = []
-        command_list_options = []
-        for component in self.list_components:
-            for name, input_text_box_list in component.input_text_boxes.items():
-
-                if name.startswith('no_arg'):
-                    continue
-
-                for input_text_box in input_text_box_list:
-                    # Allows to choose from a dropdown
-                    if type(input_text_box) == str:
-                        command_list_options.append((name, [input_text_box]))
-
-                    # Normal case where input_text_box is a TextwithButton
-                    else:
-                        is_arg = False
-                        option_values = []
-                        for textctrl in input_text_box.textctrl_list:
-                            arg = textctrl.GetValue()
-                            if arg == "" or arg is None:
-                                if input_text_box.required is True:
-                                    raise RunArgumentErrorST(
-                                        f"Argument {name} is missing a value, please enter a valid input"
-                                    )
-                            else:
-                                # Case where the option name is set to arg, this handles it as if it were an argument
-                                if name == "arg":
-                                    command_list_arguments.append(arg)
-                                    is_arg = True
-                                # Normal options
-                                else:
-                                    if name == "output":
-                                        self.output = arg
-                                    elif input_text_box.load_in_overlay:
-                                        self.load_in_overlay.append(arg)
-
-                                    option_values.append(arg)
-
-                        # If its an argument don't include it as an option, if the option list is empty don't either
-                        if not is_arg and option_values:
-                            command_list_options.append((name, option_values))
-
-        # Arguments don't need "-"
-        for arg in command_list_arguments:
-            command += [arg]
-
-        # Handles options
-        for name, args in command_list_options:
-            command += ['--' + name]
-            for arg in args:
-                command += [arg]
+    
+        for component in self.list_components:  
+            
+            cmd, output, load_in_overlay = component.get_command()
+            
+            command.extend(cmd)
+            self.load_in_overlay.extend(load_in_overlay)
+            
+            if output:
+                self.output = output
                 
-            if st_function == 'st_b0shim realtime-dynamic' and \
-            (name == 'coil' or name == 'scanner-coil-order'):
-                command += ['--' + name + '-riro']
-                for arg in args:
-                    command += [arg]
-
         msg += ' '.join(command) + '\n'
 
         return command, msg
@@ -262,11 +214,6 @@ class RunComponent(Component):
                     path_output = box_with_button_out.textctrl_list[0].GetValue()
 
             return path_output, subject
-
-
-class RunArgumentErrorST(Exception):
-    """Exception for missing input arguments for CLI call."""
-    pass
 
 
 def load_png_image_from_path(fsl_panel, image_path, is_mask=False, add_to_overlayList=True, colormap="greyscale"):

--- a/fsleyes_plugin_shimming_toolbox/components/run_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/run_component.py
@@ -191,7 +191,7 @@ class RunComponent(Component):
             cmd, output, load_in_overlay = component.get_command()
             command.extend(cmd)
             
-            if st_function.split(' ')[1] == "realtime-dynamic" and cmd[0] == "--coil":
+            if st_function.split(' ')[-1] == "realtime-dynamic" and cmd[0] == "--coil":
                 cmd_riro = ['--coil-riro' if i == '--coil' else i for i in cmd]
                 command.extend(cmd_riro)
                 

--- a/fsleyes_plugin_shimming_toolbox/components/run_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/run_component.py
@@ -189,8 +189,12 @@ class RunComponent(Component):
         for component in self.list_components:  
             
             cmd, output, load_in_overlay = component.get_command()
-            
             command.extend(cmd)
+            
+            if st_function.split(' ')[1] == "realtime-dynamic" and cmd[0] == "--coil":
+                cmd_riro = ['--coil-riro' if i == '--coil' else i for i in cmd]
+                command.extend(cmd_riro)
+                
             self.load_in_overlay.extend(load_in_overlay)
             
             if output:

--- a/fsleyes_plugin_shimming_toolbox/components/run_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/run_component.py
@@ -237,6 +237,12 @@ class RunComponent(Component):
             command += ['--' + name]
             for arg in args:
                 command += [arg]
+                
+            if st_function == 'st_b0shim realtime-dynamic' and \
+            (name == 'coil' or name == 'scanner-coil-order'):
+                command += ['--' + name + '-riro']
+                for arg in args:
+                    command += [arg]
 
         msg += ' '.join(command) + '\n'
 

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -94,11 +94,12 @@ class B0ShimTab(Tab):
             if selection == 'Dynamic/volume':
                 self.dropdown_slice_dyn.on_choice(None)
                 self.dropdown_coil_format_dyn.on_choice(None)
-                # self.dropdown_scanner_order_dyn.on_choice(None)
+                self.checkbox_scanner_order_dyn.show_children_sizers(None)
                 self.dropdown_opt_dyn.on_choice(None)
             elif selection == 'Realtime Dynamic':
                 self.dropdown_slice_rt.on_choice(None)
                 self.dropdown_coil_format_rt.on_choice(None)
+                self.checkbox_scanner_order_rt.show_children_sizers(None)
                 self.dropdown_opt_rt.on_choice(None)
         else:
             pass
@@ -188,7 +189,7 @@ class B0ShimTab(Tab):
             },
         ]
         component_scanner = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
-        
+
         dropdown_scanner_format_metadata = [
             {
                 "label": "Slicewise per Channel",
@@ -235,7 +236,7 @@ class B0ShimTab(Tab):
             }
         ]
 
-        self.checkbox_scanner_order = CheckboxComponent(
+        self.checkbox_scanner_order_dyn = CheckboxComponent(
             panel=self,
             label="Scanner Order",
             checkbox_metadata=checkbox_scanner_order_metadata,
@@ -243,7 +244,7 @@ class B0ShimTab(Tab):
             components_dict=[{'object': dropdown_scanner_format, 'checkbox': ['f0', '1', '2']},
                              {'object': component_scanner, 'checkbox': ['f0', '1', '2']}],
         )
-        
+
         dropdown_ovf_metadata = [
             {
                 "label": "delta",
@@ -419,7 +420,7 @@ class B0ShimTab(Tab):
         self.run_component_dyn = RunComponent(
             panel=self,
             list_components=[self.component_coils_dyn, component_inputs, self.dropdown_opt_dyn, self.dropdown_slice_dyn,
-                             self.checkbox_scanner_order,
+                             self.checkbox_scanner_order_dyn,
                              self.dropdown_coil_format_dyn, dropdown_ovf, component_output],
             st_function="st_b0shim dynamic",
             output_paths=["fieldmap_calculated_shim_masked.nii.gz",
@@ -522,7 +523,7 @@ class B0ShimTab(Tab):
             option_name = 'output-file-format-scanner',
             cli=realtime_cli
         )
-        
+
         checkbox_scanner_order_metadata = [
             {
                 "label": "f0",
@@ -546,8 +547,8 @@ class B0ShimTab(Tab):
             },
         ]
         component_scanner = InputComponent(self, input_text_box_metadata_scanner, cli=realtime_cli)
-        
-        self.checkbox_scanner_order = CheckboxComponent(
+
+        self.checkbox_scanner_order_rt = CheckboxComponent(
             panel=self,
             label="Scanner Order",
             checkbox_metadata=checkbox_scanner_order_metadata,
@@ -712,7 +713,7 @@ class B0ShimTab(Tab):
         self.run_component_rt = RunComponent(
             panel=self,
             list_components=[self.component_coils_rt, component_inputs, self.dropdown_opt_rt, self.dropdown_slice_rt,
-                             self.checkbox_scanner_order,
+                             self.checkbox_scanner_order_rt,
                              self.dropdown_coil_format_rt, dropdown_ovf, component_output],
             st_function="st_b0shim realtime-dynamic",
             # TODO: output paths

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -94,12 +94,12 @@ class B0ShimTab(Tab):
             if selection == 'Dynamic/volume':
                 self.dropdown_slice_dyn.on_choice(None)
                 self.dropdown_coil_format_dyn.on_choice(None)
-                self.checkbox_scanner_order_dyn.show_children_sizers(None)
+                self.checkbox_scanner_order_dyn.on_choice(None)
                 self.dropdown_opt_dyn.on_choice(None)
             elif selection == 'Realtime Dynamic':
                 self.dropdown_slice_rt.on_choice(None)
                 self.dropdown_coil_format_rt.on_choice(None)
-                self.checkbox_scanner_order_rt.show_children_sizers(None)
+                self.checkbox_scanner_order_rt.on_choice(None)
                 self.dropdown_opt_rt.on_choice(None)
         else:
             pass
@@ -228,11 +228,11 @@ class B0ShimTab(Tab):
             },
             {
                 "label": "1",
-                "option_value": "0,1"
+                "option_value": "1"
             },
             {
                 "label": "2",
-                "option_value": "0,1,2"
+                "option_value": "2"
             }
         ]
 

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -555,7 +555,8 @@ class B0ShimTab(Tab):
             option_name='scanner-coil-order',
             components_dict=[{'object': dropdown_scanner_format, 'checkbox': ['f0', '1', '2']},
                              {'object': component_scanner, 'checkbox': ['f0', '1', '2']}],
-            additional_sizer_dict={'info text': None, 'label': 'Scanner Order RIRO', 
+            additional_sizer_dict={'info text': None, 'label': 'Scanner Order RIRO',
+                                   'option name': 'scanner-coil-order-riro',
                                    'checkbox metadata': checkbox_scanner_order_metadata}
         )
 
@@ -714,7 +715,8 @@ class B0ShimTab(Tab):
 
         self.run_component_rt = RunComponent(
             panel=self,
-            list_components=[self.component_coils_rt, component_inputs, self.dropdown_opt_rt, self.dropdown_slice_rt,
+            list_components=[self.component_coils_rt, component_inputs, self.dropdown_opt_rt,
+                             self.dropdown_slice_rt,
                              self.checkbox_scanner_order_rt,
                              self.dropdown_coil_format_rt, dropdown_ovf, component_output],
             st_function="st_b0shim realtime-dynamic",

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -188,9 +188,9 @@ class B0ShimTab(Tab):
                 "name": "scanner-coil-constraints",
             },
         ]
-        component_scanner1 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
-        component_scanner2 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
-        component_scanner3 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
+        component_scanner = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
+        # component_scanner2 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
+        # component_scanner3 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
 
         dropdown_scanner_format_metadata = [
             {
@@ -215,7 +215,7 @@ class B0ShimTab(Tab):
             },
         ]
 
-        dropdown_scanner_format1 = DropdownComponent(
+        dropdown_scanner_format = DropdownComponent(
             panel=self,
             dropdown_metadata=dropdown_scanner_format_metadata,
             option_name='output-file-format-scanner',
@@ -223,29 +223,9 @@ class B0ShimTab(Tab):
             cli=dynamic_cli
         )
 
-        dropdown_scanner_format2 = DropdownComponent(
-            panel=self,
-            dropdown_metadata=dropdown_scanner_format_metadata,
-            option_name='output-file-format-scanner',
-            label="Scanner Output Format",
-            cli=dynamic_cli
-        )
-
-        dropdown_scanner_format3 = DropdownComponent(
-            panel=self,
-            dropdown_metadata=dropdown_scanner_format_metadata,
-            option_name='output-file-format-scanner',
-            label="Scanner Output Format",
-            cli=dynamic_cli
-        )
-
-        dropdown_scanner_order_metadata = [
+        checkbox_scanner_order_metadata = [
             {
-                "label": "-1",
-                "option_value": "-1"
-            },
-            {
-                "label": "0",
+                "label": "f0",
                 "option_value": "0"
             },
             {
@@ -258,18 +238,18 @@ class B0ShimTab(Tab):
             }
         ]
         
-        self.dropdown_scanner_order_dyn = DropdownComponent(
-            panel=self,
-            dropdown_metadata=dropdown_scanner_order_metadata,
-            label="Scanner Order",
-            option_name='scanner-coil-order',
-            list_components=[self.create_empty_component(),
-                             dropdown_scanner_format1, component_scanner1,
-                             dropdown_scanner_format2, component_scanner2,
-                             dropdown_scanner_format3, component_scanner3],
-            component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
-            cli=dynamic_cli
-        )
+        # self.dropdown_scanner_order_dyn = DropdownComponent(
+        #     panel=self,
+        #     dropdown_metadata=dropdown_scanner_order_metadata,
+        #     label="Scanner Order",
+        #     option_name='scanner-coil-order',
+        #     list_components=[self.create_empty_component(),
+        #                      dropdown_scanner_format1, component_scanner1,
+        #                      dropdown_scanner_format2, component_scanner2,
+        #                      dropdown_scanner_format3, component_scanner3],
+        #     component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
+        #     cli=dynamic_cli
+        # )
         # option_name='scanner-coil-order',
         #     list_components=[self.create_empty_component(),
         #                      dropdown_scanner_format1, component_scanner1,
@@ -278,13 +258,17 @@ class B0ShimTab(Tab):
         #     component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
         #     cli=dynamic_cli
 
-        dropdown_scanner_format1.add_dropdown_parent(self.dropdown_scanner_order_dyn)
-        dropdown_scanner_format2.add_dropdown_parent(self.dropdown_scanner_order_dyn)
-        dropdown_scanner_format3.add_dropdown_parent(self.dropdown_scanner_order_dyn)
+        # dropdown_scanner_format1.add_dropdown_parent(self.dropdown_scanner_order_dyn)
+        # dropdown_scanner_format2.add_dropdown_parent(self.dropdown_scanner_order_dyn)
+        # dropdown_scanner_format3.add_dropdown_parent(self.dropdown_scanner_order_dyn)
 
         self.checkbox_scanner_order = CheckboxComponent(
             panel=self,
-            label="r Order",
+            label="Scanner Order",
+            checkbox_metadata=checkbox_scanner_order_metadata,
+            option_name='scanner-coil-order',
+            components_dict=[{'object': dropdown_scanner_format, 'checkbox': ['f0', '1', '2']},
+                             {'object': component_scanner, 'checkbox': ['f0', '1', '2']}],
         )
         
         dropdown_ovf_metadata = [
@@ -462,7 +446,7 @@ class B0ShimTab(Tab):
         self.run_component_dyn = RunComponent(
             panel=self,
             list_components=[self.component_coils_dyn, component_inputs, self.dropdown_opt_dyn, self.dropdown_slice_dyn,
-                             self.checkbox_scanner_order,self.dropdown_scanner_order_dyn,
+                             self.checkbox_scanner_order,
                              self.dropdown_coil_format_dyn, dropdown_ovf, component_output],
             st_function="st_b0shim dynamic",
             output_paths=["fieldmap_calculated_shim_masked.nii.gz",
@@ -569,30 +553,14 @@ class B0ShimTab(Tab):
             },
         ]
 
-        dropdown_scanner_format1 = DropdownComponent(
+        dropdown_scanner_format = DropdownComponent(
             panel=self,
             dropdown_metadata=dropdown_scanner_format_metadata,
             label="Scanner Output Format",
             option_name = 'output-file-format-scanner',
             cli=realtime_cli
         )
-
-        dropdown_scanner_format2 = DropdownComponent(
-            panel=self,
-            dropdown_metadata=dropdown_scanner_format_metadata,
-            label="Scanner Output Format",
-            option_name = 'output-file-format-scanner',
-            cli=realtime_cli
-        )
-
-        dropdown_scanner_format3 = DropdownComponent(
-            panel=self,
-            dropdown_metadata=dropdown_scanner_format_metadata,
-            label="Scanner Output Format",
-            option_name = 'output-file-format-scanner',
-            cli=realtime_cli
-        )
-
+        
         dropdown_scanner_order_metadata = [
             {
                 "label": "-1",
@@ -618,16 +586,16 @@ class B0ShimTab(Tab):
             label="Scanner Order",
             option_name = 'scanner-coil-order',
             list_components=[self.create_empty_component(),
-                             dropdown_scanner_format1, component_scanner1,
-                             dropdown_scanner_format2, component_scanner2,
-                             dropdown_scanner_format3, component_scanner3],
+                             dropdown_scanner_format, component_scanner1,
+                             dropdown_scanner_format, component_scanner2,
+                             dropdown_scanner_format, component_scanner3],
             component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
             cli=realtime_cli
         )
 
-        dropdown_scanner_format1.add_dropdown_parent(self.dropdown_scanner_order_rt)
-        dropdown_scanner_format2.add_dropdown_parent(self.dropdown_scanner_order_rt)
-        dropdown_scanner_format3.add_dropdown_parent(self.dropdown_scanner_order_rt)
+        dropdown_scanner_format.add_dropdown_parent(self.dropdown_scanner_order_rt)
+        dropdown_scanner_format.add_dropdown_parent(self.dropdown_scanner_order_rt)
+        dropdown_scanner_format.add_dropdown_parent(self.dropdown_scanner_order_rt)
 
         dropdown_ovf_metadata = [
             {

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -547,7 +547,7 @@ class B0ShimTab(Tab):
             },
         ]
         component_scanner = InputComponent(self, input_text_box_metadata_scanner, cli=realtime_cli)
-
+            
         self.checkbox_scanner_order_rt = CheckboxComponent(
             panel=self,
             label="Scanner Order",
@@ -555,6 +555,8 @@ class B0ShimTab(Tab):
             option_name='scanner-coil-order',
             components_dict=[{'object': dropdown_scanner_format, 'checkbox': ['f0', '1', '2']},
                              {'object': component_scanner, 'checkbox': ['f0', '1', '2']}],
+            additional_sizer_dict={'info text': None, 'label': 'Scanner Order RIRO', 
+                                   'checkbox metadata': checkbox_scanner_order_metadata}
         )
 
         dropdown_ovf_metadata = [

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -99,7 +99,6 @@ class B0ShimTab(Tab):
             elif selection == 'Realtime Dynamic':
                 self.dropdown_slice_rt.on_choice(None)
                 self.dropdown_coil_format_rt.on_choice(None)
-                self.dropdown_scanner_order_rt.on_choice(None)
                 self.dropdown_opt_rt.on_choice(None)
         else:
             pass
@@ -189,9 +188,7 @@ class B0ShimTab(Tab):
             },
         ]
         component_scanner = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
-        # component_scanner2 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
-        # component_scanner3 = InputComponent(self, input_text_box_metadata_scanner, cli=dynamic_cli)
-
+        
         dropdown_scanner_format_metadata = [
             {
                 "label": "Slicewise per Channel",
@@ -237,30 +234,6 @@ class B0ShimTab(Tab):
                 "option_value": "0,1,2"
             }
         ]
-        
-        # self.dropdown_scanner_order_dyn = DropdownComponent(
-        #     panel=self,
-        #     dropdown_metadata=dropdown_scanner_order_metadata,
-        #     label="Scanner Order",
-        #     option_name='scanner-coil-order',
-        #     list_components=[self.create_empty_component(),
-        #                      dropdown_scanner_format1, component_scanner1,
-        #                      dropdown_scanner_format2, component_scanner2,
-        #                      dropdown_scanner_format3, component_scanner3],
-        #     component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
-        #     cli=dynamic_cli
-        # )
-        # option_name='scanner-coil-order',
-        #     list_components=[self.create_empty_component(),
-        #                      dropdown_scanner_format1, component_scanner1,
-        #                      dropdown_scanner_format2, component_scanner2,
-        #                      dropdown_scanner_format3, component_scanner3],
-        #     component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
-        #     cli=dynamic_cli
-
-        # dropdown_scanner_format1.add_dropdown_parent(self.dropdown_scanner_order_dyn)
-        # dropdown_scanner_format2.add_dropdown_parent(self.dropdown_scanner_order_dyn)
-        # dropdown_scanner_format3.add_dropdown_parent(self.dropdown_scanner_order_dyn)
 
         self.checkbox_scanner_order = CheckboxComponent(
             panel=self,
@@ -507,17 +480,6 @@ class B0ShimTab(Tab):
 
         component_inputs = InputComponent(self, input_text_box_metadata_inputs, cli=realtime_cli)
 
-        input_text_box_metadata_scanner = [
-            {
-                "button_label": "Scanner constraints",
-                "button_function": "select_file",
-                "name": "scanner-coil-constraints",
-            },
-        ]
-        component_scanner1 = InputComponent(self, input_text_box_metadata_scanner, cli=realtime_cli)
-        component_scanner2 = InputComponent(self, input_text_box_metadata_scanner, cli=realtime_cli)
-        component_scanner3 = InputComponent(self, input_text_box_metadata_scanner, cli=realtime_cli)
-
         input_text_box_metadata_slice = [
             {
                 "button_label": "Slice Factor",
@@ -561,13 +523,9 @@ class B0ShimTab(Tab):
             cli=realtime_cli
         )
         
-        dropdown_scanner_order_metadata = [
+        checkbox_scanner_order_metadata = [
             {
-                "label": "-1",
-                "option_value": "-1"
-            },
-            {
-                "label": "0",
+                "label": "f0",
                 "option_value": "0"
             },
             {
@@ -580,22 +538,23 @@ class B0ShimTab(Tab):
             }
         ]
 
-        self.dropdown_scanner_order_rt = DropdownComponent(
+        input_text_box_metadata_scanner = [
+            {
+                "button_label": "Scanner constraints",
+                "button_function": "select_file",
+                "name": "scanner-coil-constraints",
+            },
+        ]
+        component_scanner = InputComponent(self, input_text_box_metadata_scanner, cli=realtime_cli)
+        
+        self.checkbox_scanner_order = CheckboxComponent(
             panel=self,
-            dropdown_metadata=dropdown_scanner_order_metadata,
             label="Scanner Order",
-            option_name = 'scanner-coil-order',
-            list_components=[self.create_empty_component(),
-                             dropdown_scanner_format, component_scanner1,
-                             dropdown_scanner_format, component_scanner2,
-                             dropdown_scanner_format, component_scanner3],
-            component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
-            cli=realtime_cli
+            checkbox_metadata=checkbox_scanner_order_metadata,
+            option_name='scanner-coil-order',
+            components_dict=[{'object': dropdown_scanner_format, 'checkbox': ['f0', '1', '2']},
+                             {'object': component_scanner, 'checkbox': ['f0', '1', '2']}],
         )
-
-        dropdown_scanner_format.add_dropdown_parent(self.dropdown_scanner_order_rt)
-        dropdown_scanner_format.add_dropdown_parent(self.dropdown_scanner_order_rt)
-        dropdown_scanner_format.add_dropdown_parent(self.dropdown_scanner_order_rt)
 
         dropdown_ovf_metadata = [
             {
@@ -753,7 +712,7 @@ class B0ShimTab(Tab):
         self.run_component_rt = RunComponent(
             panel=self,
             list_components=[self.component_coils_rt, component_inputs, self.dropdown_opt_rt, self.dropdown_slice_rt,
-                             self.dropdown_scanner_order_rt,
+                             self.checkbox_scanner_order,
                              self.dropdown_coil_format_rt, dropdown_ovf, component_output],
             st_function="st_b0shim realtime-dynamic",
             # TODO: output paths

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -249,11 +249,11 @@ class B0ShimTab(Tab):
             },
             {
                 "label": "1",
-                "option_value": "1"
+                "option_value": "0,1"
             },
             {
                 "label": "2",
-                "option_value": "2"
+                "option_value": "0,1,2"
             }
         ]
 
@@ -591,11 +591,11 @@ class B0ShimTab(Tab):
             },
             {
                 "label": "1",
-                "option_value": "1"
+                "option_value": "0,1"
             },
             {
                 "label": "2",
-                "option_value": "2"
+                "option_value": "0,1,2"
             }
         ]
 

--- a/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
+++ b/fsleyes_plugin_shimming_toolbox/tabs/b0shim_tab.py
@@ -9,6 +9,7 @@ from fsleyes_plugin_shimming_toolbox.tabs.tab import Tab
 from fsleyes_plugin_shimming_toolbox.components.dropdown_component import DropdownComponent
 from fsleyes_plugin_shimming_toolbox.components.input_component import InputComponent
 from fsleyes_plugin_shimming_toolbox.components.run_component import RunComponent
+from fsleyes_plugin_shimming_toolbox.components.checkbox_component import CheckboxComponent
 
 from shimmingtoolbox.cli.b0shim import dynamic as dynamic_cli
 from shimmingtoolbox.cli.b0shim import realtime_dynamic as realtime_cli
@@ -93,7 +94,7 @@ class B0ShimTab(Tab):
             if selection == 'Dynamic/volume':
                 self.dropdown_slice_dyn.on_choice(None)
                 self.dropdown_coil_format_dyn.on_choice(None)
-                self.dropdown_scanner_order_dyn.on_choice(None)
+                # self.dropdown_scanner_order_dyn.on_choice(None)
                 self.dropdown_opt_dyn.on_choice(None)
             elif selection == 'Realtime Dynamic':
                 self.dropdown_slice_rt.on_choice(None)
@@ -256,7 +257,7 @@ class B0ShimTab(Tab):
                 "option_value": "0,1,2"
             }
         ]
-
+        
         self.dropdown_scanner_order_dyn = DropdownComponent(
             panel=self,
             dropdown_metadata=dropdown_scanner_order_metadata,
@@ -269,11 +270,23 @@ class B0ShimTab(Tab):
             component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
             cli=dynamic_cli
         )
+        # option_name='scanner-coil-order',
+        #     list_components=[self.create_empty_component(),
+        #                      dropdown_scanner_format1, component_scanner1,
+        #                      dropdown_scanner_format2, component_scanner2,
+        #                      dropdown_scanner_format3, component_scanner3],
+        #     component_to_dropdown_choice=[0, 1, 1, 2, 2, 3, 3],
+        #     cli=dynamic_cli
 
         dropdown_scanner_format1.add_dropdown_parent(self.dropdown_scanner_order_dyn)
         dropdown_scanner_format2.add_dropdown_parent(self.dropdown_scanner_order_dyn)
         dropdown_scanner_format3.add_dropdown_parent(self.dropdown_scanner_order_dyn)
 
+        self.checkbox_scanner_order = CheckboxComponent(
+            panel=self,
+            label="r Order",
+        )
+        
         dropdown_ovf_metadata = [
             {
                 "label": "delta",
@@ -449,7 +462,7 @@ class B0ShimTab(Tab):
         self.run_component_dyn = RunComponent(
             panel=self,
             list_components=[self.component_coils_dyn, component_inputs, self.dropdown_opt_dyn, self.dropdown_slice_dyn,
-                             self.dropdown_scanner_order_dyn,
+                             self.checkbox_scanner_order,self.dropdown_scanner_order_dyn,
                              self.dropdown_coil_format_dyn, dropdown_ovf, component_output],
             st_function="st_b0shim dynamic",
             output_paths=["fieldmap_calculated_shim_masked.nii.gz",

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -35,7 +35,7 @@ source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
 # Install fsleyes
 print info "Installing fsleyes"
-"${ST_DIR}"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge fsleyes=1.9.0 python=3.9
+"${ST_DIR}"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge fsleyes=1.9.0 python=3.10
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION="c9975f7d6bc8bcc4c79ad73fef59c9b938b156dc"
+ST_VERSION="072aaa8b47ab7ded0e7a2f5256ea37af0f038c9f"
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -14,7 +14,7 @@ rm -rf "${ST_DIR}/shimming-toolbox"
 
 print info "Downloading Shimming-Toolbox"
 
-ST_VERSION="072aaa8b47ab7ded0e7a2f5256ea37af0f038c9f"
+ST_VERSION="857908fc08ad24845b219e872893487be065a4ee"
 
 curl -L "https://github.com/shimming-toolbox/shimming-toolbox/archive/${ST_VERSION}.zip" > "shimming-toolbox-${ST_VERSION}.zip"
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 
 setup(
-    # the name must begin with "fsleyes-plugin-"
     name='fsleyes-plugin-shimming-toolbox',
     install_requires=[
         "imageio",
@@ -9,23 +8,12 @@ setup(
     ],
     packages=find_packages(exclude=['.git']),
     include_package_data=True,
-
-    # Views, controls, and tools must be exposed
-    # as entry points within groups called
-    # "fsleyes_views", "fsleyes_controls" and
-    # "fsleyes_tools" respectively.
     entry_points={
-        # 'fsleyes_views': [
-        #     'My cool view = myplugin:MyView'
-        # ],
         'fsleyes_controls': [
             'Shimming Toolbox = fsleyes_plugin_shimming_toolbox.st_plugin:STControlPanel'
         ],
         'fsleyes_layouts': [
             'Shimming Toolbox = fsleyes_plugin_shimming_toolbox.st_plugin:STLayout'
         ],
-        # 'fsleyes_tools': [
-        #     'My cool tool = myplugin:MyTool'
-        # ]
     }
 )

--- a/test/gui/test_b0shim_tab.py
+++ b/test/gui/test_b0shim_tab.py
@@ -21,7 +21,7 @@ def test_st_plugin_b0shim_dyn_lsq_mse():
     options = {'optimizer-method': 'Least Squares',
                'optimizer-criteria': 'Mean Squared Error',
                'slices': 'Auto detect',
-               'scanner-coil-order': '0,1,2',
+               'scanner-coil-order': '0',
                'output-file-format-scanner': 'Slicewise per Channel',
                'output-file-format-coil': 'Slicewise per Channel',
                'fatsat': 'Auto detect',

--- a/test/gui/test_b0shim_tab.py
+++ b/test/gui/test_b0shim_tab.py
@@ -21,7 +21,7 @@ def test_st_plugin_b0shim_dyn_lsq_mse():
     options = {'optimizer-method': 'Least Squares',
                'optimizer-criteria': 'Mean Squared Error',
                'slices': 'Auto detect',
-               'scanner-coil-order': '1',
+               'scanner-coil-order': '0,1,2',
                'output-file-format-scanner': 'Slicewise per Channel',
                'output-file-format-coil': 'Slicewise per Channel',
                'fatsat': 'Auto detect',
@@ -123,8 +123,6 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
             if isinstance(widget, wx.Choice) and widget.IsShown():
                 if widget.GetName() == 'optimizer-method':
                     assert set_dropdown_selection(widget, options['optimizer-method'])
-                # if widget.GetName() == 'scanner-coil-order':
-                #     assert set_dropdown_selection(widget, options['scanner-coil-order'])
                 if widget.GetName() == 'slices':
                     assert set_dropdown_selection(widget, options['slices'])
                 if widget.GetName() == 'output-value-format':
@@ -173,6 +171,7 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
                         if isinstance(new_widget, wx.TextCtrl) and new_widget.IsShown():
                             if new_widget.GetName() == 'input_coil_1' and counter == 0:
                                 new_widget.SetValue(fname_coil)
+                                counter += 1
                                 realYield()
                             elif new_widget.GetName() == 'input_coil_1' and counter == 1:
                                 new_widget.SetValue(fname_coil_json)

--- a/test/gui/test_b0shim_tab.py
+++ b/test/gui/test_b0shim_tab.py
@@ -11,7 +11,7 @@ import tempfile
 import time
 import wx
 
-from .test_tabs import get_notebook, set_notebook_page, get_tab, get_all_children, set_dropdown_selection
+from .test_tabs import get_notebook, set_notebook_page, get_tab, get_all_children, set_dropdown_selection, set_checkbox
 from .. import realYield, run_with_orthopanel
 from fsleyes_plugin_shimming_toolbox import __dir_testing__
 from fsleyes_plugin_shimming_toolbox.tabs.b0shim_tab import B0ShimTab
@@ -89,17 +89,22 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
     assert b0shim_tab is not None
 
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-        nii_fmap, nii_anat, nii_mask, fm_data, anat_data = _define_inputs(fmap_dim=3)
+        nii_fmap, nii_anat, nii_mask, nii_coil, fm_data, anat_data, coil_data = _define_inputs(fmap_dim=3)
         fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
         fname_fm_json = os.path.join(tmp, 'fmap.json')
         fname_mask = os.path.join(tmp, 'mask.nii.gz')
         fname_anat = os.path.join(tmp, 'anat.nii.gz')
         fname_anat_json = os.path.join(tmp, 'anat.json')
+        fname_coil = os.path.join(tmp, 'coil.nii.gz')
+        fname_coil_json = os.path.join(tmp, 'coil.json')
+        
         _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
                      nii_anat=nii_anat, fname_anat=fname_anat,
                      nii_mask=nii_mask, fname_mask=fname_mask,
+                     nii_coil=nii_coil, fname_coil=fname_coil,
                      fm_data=fm_data, fname_fm_json=fname_fm_json,
-                     anat_data=anat_data, fname_anat_json=fname_anat_json)
+                     anat_data=anat_data, fname_anat_json=fname_anat_json,
+                     coil_data=coil_data, fname_coil_json=fname_coil_json)
         fname_output = os.path.join(tmp, 'fieldmap.nii.gz')
 
         # Fill in the B0 shim tab options
@@ -118,14 +123,23 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
             if isinstance(widget, wx.Choice) and widget.IsShown():
                 if widget.GetName() == 'optimizer-method':
                     assert set_dropdown_selection(widget, options['optimizer-method'])
-                if widget.GetName() == 'scanner-coil-order':
-                    assert set_dropdown_selection(widget, options['scanner-coil-order'])
+                # if widget.GetName() == 'scanner-coil-order':
+                #     assert set_dropdown_selection(widget, options['scanner-coil-order'])
                 if widget.GetName() == 'slices':
                     assert set_dropdown_selection(widget, options['slices'])
-                if widget.GetName() == 'scanner-coil-order':
-                    assert set_dropdown_selection(widget, options['scanner-coil-order'])
                 if widget.GetName() == 'output-value-format':
                     assert set_dropdown_selection(widget, options['output-value-format'])
+        
+        # Select the checkboxes
+        list_widgets = []
+        get_all_children(b0shim_tab.sizer_run, list_widgets)
+        for widget in list_widgets:
+            if isinstance(widget, wx.CheckBox) and widget.IsShown():
+                if widget.GetName() == 'check':
+                    widget.SetValue(True)
+                    assert set_checkbox(widget)
+                    realYield()
+            
         # Select the dropdowns that are nested
         list_widgets = []
         get_all_children(b0shim_tab.sizer_run, list_widgets)
@@ -151,7 +165,18 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
         for widget in list_widgets:
             if isinstance(widget, wx.TextCtrl) and widget.IsShown():
                 if widget.GetName() == 'no_arg_ncoils_dyn':
-                    widget.SetValue('0')
+                    widget.SetValue('1')
+                    new_widget_list = []
+                    counter = 0
+                    get_all_children(b0shim_tab.sizer_run, new_widget_list)
+                    for new_widget in new_widget_list:
+                        if isinstance(new_widget, wx.TextCtrl) and new_widget.IsShown():
+                            if new_widget.GetName() == 'input_coil_1' and counter == 0:
+                                new_widget.SetValue(fname_coil)
+                                realYield()
+                            elif new_widget.GetName() == 'input_coil_1' and counter == 1:
+                                new_widget.SetValue(fname_coil_json)
+                                realYield()
                     realYield()
                 if widget.GetName() == 'fmap':
                     widget.SetValue(fname_fmap)
@@ -228,14 +253,21 @@ def _define_inputs(fmap_dim):
 
     nii_mask = nib.Nifti1Image(mask.astype(np.uint8), nii_anat.affine)
 
-    return nii_fmap, nii_anat, nii_mask, fm_data, anat_data
+    fname_coil_nii = os.path.join(__dir_testing__, 'ds_coil', 'NP15ch_coil_profiles.nii.gz')
+    nii_coil = nib.load(fname_coil_nii)
+    fname_coil_json = os.path.join(__dir_testing__, 'ds_coil', 'NP15ch_config.json')
+    coil_data = json.load(open(fname_coil_json))
+    
+    return nii_fmap, nii_anat, nii_mask, nii_coil, fm_data, anat_data, coil_data
 
 
 def _save_inputs(nii_fmap=None, fname_fmap=None,
                  nii_anat=None, fname_anat=None,
                  nii_mask=None, fname_mask=None,
+                 nii_coil=None, fname_coil=None,
                  fm_data=None, fname_fm_json=None,
-                 anat_data=None, fname_anat_json=None):
+                 anat_data=None, fname_anat_json=None,
+                 coil_data=None, fname_coil_json=None,):
     """Save inputs if they are not None, use the respective fnames for the different inputs to save"""
     if nii_fmap is not None:
         # Save the fieldmap
@@ -258,3 +290,12 @@ def _save_inputs(nii_fmap=None, fname_fmap=None,
     if nii_mask is not None:
         # Save the mask
         nib.save(nii_mask, fname_mask)
+    
+    if nii_coil is not None:
+        # Save the coil
+        nib.save(nii_coil, fname_coil)
+    
+    if coil_data is not None:
+        # Save json
+        with open(fname_coil_json, 'w', encoding='utf-8') as f:
+            json.dump(coil_data, f, indent=4)

--- a/test/gui/test_b0shim_tab.py
+++ b/test/gui/test_b0shim_tab.py
@@ -134,9 +134,7 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
         for widget in list_widgets:
             if isinstance(widget, wx.CheckBox) and widget.IsShown():
                 if widget.GetName() == 'check':
-                    widget.SetValue(True)
                     assert set_checkbox(widget)
-                    realYield()
             
         # Select the dropdowns that are nested
         list_widgets = []

--- a/test/gui/test_tabs.py
+++ b/test/gui/test_tabs.py
@@ -99,3 +99,4 @@ def set_checkbox(checkbox_widget):
     wx.PostEvent(checkbox_widget.GetEventHandler(), wx.CommandEvent(wx.EVT_CHECKBOX.typeId, checkbox_widget.GetId()))
     realYield()
     return True
+    

--- a/test/gui/test_tabs.py
+++ b/test/gui/test_tabs.py
@@ -94,7 +94,7 @@ def set_dropdown_selection(dropdown_widget, selection_name):
 
 
 def set_checkbox(checkbox_widget):
-    """ Sets the notebook terminal to the page with the given name."""
+    """ Sets the checkbox to True."""
     checkbox_widget.SetValue(True)
     wx.PostEvent(checkbox_widget.GetEventHandler(), wx.CommandEvent(wx.EVT_CHECKBOX.typeId, checkbox_widget.GetId()))
     realYield()

--- a/test/gui/test_tabs.py
+++ b/test/gui/test_tabs.py
@@ -91,3 +91,11 @@ def set_dropdown_selection(dropdown_widget, selection_name):
             realYield()
             return True
     return False
+
+
+def set_checkbox(checkbox_widget):
+    """ Sets the notebook terminal to the page with the given name."""
+    checkbox_widget.SetValue(True)
+    wx.PostEvent(checkbox_widget.GetEventHandler(), wx.CommandEvent(wx.EVT_CHECKBOX.typeId, checkbox_widget.GetId()))
+    realYield()
+    return True


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks. It's ok to repeat some text from the related issue. -->
With the new shimming-toolbox update letting users select specific orders from the scanner, this PR is to update the GUI prompts to use the new syntax. The GUI will only allow using all orders below the select one and use the same scanner orders and coils with riro and static.

