### PR TITLE
bug fix

### DIFF
--- a/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
+++ b/fsleyes_plugin_shimming_toolbox/components/checkbox_component.py
@@ -111,6 +111,9 @@ class CheckboxComponent(Component):
             if checkbox.GetValue():
                 label = checkbox.GetLabel()
                 args += option_values[label] + ','
+        if args == "":
+            return "-1"
+        
         return args[:-1]
     
     def get_command(self):

--- a/test/gui/test_b0shim_tab.py
+++ b/test/gui/test_b0shim_tab.py
@@ -21,7 +21,7 @@ def test_st_plugin_b0shim_dyn_lsq_mse():
     options = {'optimizer-method': 'Least Squares',
                'optimizer-criteria': 'Mean Squared Error',
                'slices': 'Auto detect',
-               'scanner-coil-order': '0',
+               'scanner-coil-order': 'f0',
                'output-file-format-scanner': 'Slicewise per Channel',
                'output-file-format-coil': 'Slicewise per Channel',
                'fatsat': 'Auto detect',
@@ -46,6 +46,21 @@ def test_st_plugin_b0shim_dyn_lsq_mae():
     def _test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options=options):
         __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options=options)
     run_with_orthopanel(_test_st_plugin_b0shim_dyn)
+    
+    
+def test_st_plugin_b0shim_dyn_lsq_mse_coil_only():
+    options = {'optimizer-method': 'Least Squares',
+               'optimizer-criteria': 'Mean Absolute Error',
+               'slices': 'Auto detect',
+               'scanner-coil-order': '',
+               'output-file-format-scanner': 'Slicewise per Channel',
+               'output-file-format-coil': 'Slicewise per Channel',
+               'output-value-format': 'delta'
+               }
+
+    def _test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options=options):
+        __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options=options)
+    run_with_orthopanel(_test_st_plugin_b0shim_dyn)
 
 
 def test_st_plugin_b0shim_dyn_pi():
@@ -60,8 +75,8 @@ def test_st_plugin_b0shim_dyn_pi():
     def _test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options=options):
         __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options=options)
     run_with_orthopanel(_test_st_plugin_b0shim_dyn)
-
-
+    
+    
 def test_st_plugin_b0shim_dyn_qp():
     options = {'optimizer-method': 'Quad Prog',
                'optimizer-criteria': 'Mean Squared Error',
@@ -133,7 +148,7 @@ def __test_st_plugin_b0shim_dyn(view, overlayList, displayCtx, options):
         get_all_children(b0shim_tab.sizer_run, list_widgets)
         for widget in list_widgets:
             if isinstance(widget, wx.CheckBox) and widget.IsShown():
-                if widget.GetName() == 'check':
+                if widget.Label in options['scanner-coil-order']:
                     assert set_checkbox(widget)
             
         # Select the dropdowns that are nested


### PR DESCRIPTION
## Checklist

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
There was a bug where if no order was selected in the GUI, the ran command would send an empty string as coil orders. Changed it to -1.